### PR TITLE
feat: add citations object to CompletionResponse

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,9 @@ func main() {
 	}
 
 	fmt.Println(res.GetLastContent())
+	for i, c := range res.GetCitations() {
+		fmt.Printf("Citation %d: %s", i+1, c)
+	}
 	// fmt.Printf("%+v\n", *req)
 	// fmt.Println("*************")
 	// fmt.Printf("%+v\n", res)

--- a/perplexity_response.go
+++ b/perplexity_response.go
@@ -22,12 +22,13 @@ type Choice struct {
 
 // CompletionResponse is a response object for the Perplexity API.
 type CompletionResponse struct {
-	ID      string   `json:"id"`
-	Model   string   `json:"model"`
-	Created int      `json:"created"`
-	Usage   Usage    `json:"usage"`
-	Object  string   `json:"object"`
-	Choices []Choice `json:"choices"`
+	ID        string    `json:"id"`
+	Model     string    `json:"model"`
+	Created   int       `json:"created"`
+	Usage     Usage     `json:"usage"`
+	Object    string    `json:"object"`
+	Choices   []Choice  `json:"choices"`
+	Citations *[]string `json:"citations,omitempty"`
 }
 
 // String returns a string representation of the CompletionResponse.
@@ -40,7 +41,7 @@ func (r *CompletionResponse) String() string {
 	}
 	b, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
-		return err.Error()
+		return ""
 	}
 	return string(b)
 }
@@ -51,4 +52,12 @@ func (r *CompletionResponse) GetLastContent() string {
 		return ""
 	}
 	return r.Choices[len(r.Choices)-1].Message.Content
+}
+
+// GetCitations returns the citations of the completion response.
+func (r *CompletionResponse) GetCitations() []string {
+	if r.Citations == nil {
+		return []string{}
+	}
+	return *r.Citations
 }

--- a/perplexity_response.go
+++ b/perplexity_response.go
@@ -41,7 +41,7 @@ func (r *CompletionResponse) String() string {
 	}
 	b, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
-		return ""
+		return err.Error()
 	}
 	return string(b)
 }

--- a/perplexity_response_test.go
+++ b/perplexity_response_test.go
@@ -78,3 +78,24 @@ func TestString(t *testing.T) {
 		assert.Equal(t, "{\n  \"id\": \"id\",\n  \"model\": \"model\",\n  \"created\": 1,\n  \"usage\": {\n    \"prompt_tokens\": 1,\n    \"completion_tokens\": 1,\n    \"total_tokens\": 1\n  },\n  \"object\": \"object\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"finish_reason\": \"\",\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"hello\"\n      },\n      \"delta\": {\n        \"role\": \"\",\n        \"content\": \"\"\n      }\n    }\n  ]\n}", content.String())
 	})
 }
+
+func TestGetCitations(t *testing.T) {
+	t.Run("empty response returns empty citations", func(t *testing.T) {
+		content := perplexity.CompletionResponse{}
+		assert.Equal(t, content.GetCitations(), []string{})
+	})
+
+	t.Run("nil citations returns empty citations", func(t *testing.T) {
+		content := perplexity.CompletionResponse{
+			Citations: nil,
+		}
+		assert.Equal(t, content.GetCitations(), []string{})
+	})
+
+	t.Run("case with a real citations", func(t *testing.T) {
+		content := perplexity.CompletionResponse{
+			Citations: &[]string{"citation1", "citation2"},
+		}
+		assert.Equal(t, content.GetCitations(), []string{"citation1", "citation2"})
+	})
+}


### PR DESCRIPTION
This PR adds a nullable `citations` field to the `CompletionResponse` object and a `GetCitations` function which returns the string array.

If the Perplexity API returns a null `citations` object, the `citations` field in `CompletionResponse` will also be null. 

[API Docs Source](https://docs.perplexity.ai/api-reference/chat-completions#response-citations)