### PR TITLE
feat: allow requests without setting 'search_recency_filter'

### DIFF
--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -55,7 +55,7 @@ type CompletionRequest struct {
 	ReturnRelatedQuestions bool `json:"return_related_questions"`
 	// SearchRecencyFilter: Returns search results within the specified time interval - does not apply to images.
 	// Values include year, month, week, day, hour
-	SearchRecencyFilter string `json:"search_recency_filter"`
+	SearchRecencyFilter string `json:"search_recency_filter,omitempty" validate:"omitempty,oneof=year month week day hour"`
 	// TopK: The number of tokens to keep for highest top-k filtering,
 	// specified as an integer between 0 and 2048 inclusive.
 	// If set to 0, top-k filtering is disabled.

--- a/perplexity_request_test.go
+++ b/perplexity_request_test.go
@@ -3,6 +3,7 @@ package perplexity_test
 import (
 	"testing"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/sgaunet/perplexity-go/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -86,6 +87,45 @@ func TestWithSearchRecencyFilter(t *testing.T) {
 		req := perplexity.NewCompletionRequest(perplexity.WithSearchRecencyFilter(searchRecencyFilter))
 		assert.Equal(t, req.SearchRecencyFilter, searchRecencyFilter)
 	})
+}
+
+func TestSearchRecencyFilterValidationRule(t *testing.T) {
+	validate := validator.New()
+	tests := []struct {
+		name    string
+		value   string
+		valid   bool
+	}{
+		{"empty value", "", true},
+		{"year is valid", "year", true},
+		{"month is valid", "month", true},
+		{"week is valid", "week", true},
+		{"day is valid", "day", true},
+		{"hour is valid", "hour", true},
+		{"invalid value foo", "foo", false},
+		{"invalid value 2022", "2022", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &perplexity.CompletionRequest{
+				Messages:             []perplexity.Message{{Role: "user", Content: "test"}},
+				Model:                perplexity.DefaultModel,
+				MaxTokens:            10,
+				Temperature:          1.0,
+				TopP:                 0.5,
+				SearchRecencyFilter:  test.value,
+				TopK:                 10,
+				PresencePenalty:      0.0,
+				FrequencyPenalty:     1.0,
+			}
+			err := validate.Struct(req)
+			if test.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
 }
 
 func TestWithTopK(t *testing.T) {


### PR DESCRIPTION
### Allow Requests Without The "search_recency_filter"

**TLDR: don't include _search_recency_filter_ if the value is empty**


Perplexity's API does not require a value for the search_recency_filter.

However if the is a key "search_recency_filter" in the request body, the value of the key must be one of the follow: "year","month","week","day","hour"

When marshaling CompletionRequest to json, we need to omit empty values for "search_recency_filter"