### PR TITLE
50 add golangci lint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,33 @@
+name: linter
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.24'
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.12.0
+        with:
+          enable-cache: true
+          devbox-version: 0.14.0
+
+      - name: Install prerequisites
+        shell: /usr/bin/bash {0}
+        run: |
+          devbox install
+          devbox run linter

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+/.devbox

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+---
+version: "2"
+# Configure which files to skip during linting
+run:
+  tests: false
+
+linters:
+  default: all
+
+  disable:
+    - wsl
+    - nlreturn
+    - depguard
+    - gochecknoinits
+    - gochecknoglobals
+    - forbidigo
+    - varnamelen
+    - exhaustruct

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,3 +20,8 @@ linters:
     - tagliatelle
     - lll
     - funlen
+    - tagalign
+
+  exclusions:
+    paths:
+      - cmd/*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,3 +18,5 @@ linters:
     - exhaustruct
     - errcheck
     - tagliatelle
+    - lll
+    - funlen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,5 @@ linters:
     - forbidigo
     - varnamelen
     - exhaustruct
+    - errcheck
+    - tagliatelle

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GoDoc](https://godoc.org/github.com/sgaunet/perplexity-go/v2?status.svg)](https://godoc.org/github.com/sgaunet/perplexity-go/v2)
 [![CI](https://github.com/sgaunet/perplexity-go/actions/workflows/coverage.yml/badge.svg)](https://github.com/sgaunet/perplexity-go/actions/workflows/coverage.yml)
 [![Release](https://github.com/sgaunet/perplexity-go/actions/workflows/release.yml/badge.svg)](https://github.com/sgaunet/perplexity-go/actions/workflows/release.yml)
+[![golangci-lint](https://github.com/sgaunet/perplexity-go/actions/workflows/linter.yml/badge.svg)](https://github.com/sgaunet/perplexity-go/actions/workflows/linter.yml)
 
 A lightweight Go library for interacting with the [Perplexity AI API](https://docs.perplexity.ai/reference/post_chat_completions), focusing on the chat completion endpoint.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,3 +19,9 @@ tasks:
         fi
       - go tool cover -func profile.cov | grep '^total:' | awk '{print $3}' | sed "s/%//"
       - rm -f profile.cov
+
+  linter:
+    desc: "Run linter"
+    cmds:
+      - go generate ./...
+      - golangci-lint run

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sgaunet/perplexity-go/v2"
 )
 
-// This example demonstrates how to create a completion request with web search options
+// This example demonstrates how to create a completion request with web search options.
 func main() {
 	client := perplexity.NewClient(os.Getenv("PPLX_API_KEY"))
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,4 @@
+// Package main provides the command-line interface for the Perplexity API client.
 package main
 
 import (

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.4/.schema/devbox.schema.json",
+  "packages": [
+    "goreleaser@2.9.0",
+    "go-task@3.41.0",
+    "golangci-lint@2.1.6"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "linter": [
+        "task linter"
+      ]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,129 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "go-task@3.41.0": {
+      "last_modified": "2025-04-17T05:47:26Z",
+      "resolved": "github:NixOS/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c#go-task",
+      "source": "devbox-search",
+      "version": "3.41.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zz0ydwqf8s4dmdrhrd2i8h467mxsdgib-go-task-3.41.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zz0ydwqf8s4dmdrhrd2i8h467mxsdgib-go-task-3.41.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gw5m0vszm1arqri0f23x2myhn48njy8a-go-task-3.41.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gw5m0vszm1arqri0f23x2myhn48njy8a-go-task-3.41.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hyp3mswald858k3kpbyc63h4dz2xfl18-go-task-3.41.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hyp3mswald858k3kpbyc63h4dz2xfl18-go-task-3.41.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h39sp829c75dccfp5jk8a5aqap4gpn8m-go-task-3.41.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/h39sp829c75dccfp5jk8a5aqap4gpn8m-go-task-3.41.0"
+        }
+      }
+    },
+    "golangci-lint@2.1.6": {
+      "last_modified": "2025-05-06T08:06:31Z",
+      "resolved": "github:NixOS/nixpkgs/1cb1c02a6b1b7cf67e3d7731cbbf327a53da9679#golangci-lint",
+      "source": "devbox-search",
+      "version": "2.1.6",
+      "systems": {
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nzfzphypaibr5md38sqjm91i8azhynj4-golangci-lint-2.1.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nzfzphypaibr5md38sqjm91i8azhynj4-golangci-lint-2.1.6"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/05p9lrvs0d7qqcd2vdks2lvmvi0kdp05-golangci-lint-2.1.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/05p9lrvs0d7qqcd2vdks2lvmvi0kdp05-golangci-lint-2.1.6"
+        }
+      }
+    },
+    "goreleaser@2.9.0": {
+      "last_modified": "2025-04-30T16:14:55Z",
+      "resolved": "github:NixOS/nixpkgs/70b191e2e0b1b5fe8586ad939dfa01f3047865f7#goreleaser",
+      "source": "devbox-search",
+      "version": "2.9.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/80r1z38i8184lp7xxcs6ss9khszh4gyf-goreleaser-2.9.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/80r1z38i8184lp7xxcs6ss9khszh4gyf-goreleaser-2.9.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pg2by80fn5i3dgxkl0ad4m56njvpjnax-goreleaser-2.9.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/pg2by80fn5i3dgxkl0ad4m56njvpjnax-goreleaser-2.9.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/r879776j6ymhyd3fg1jlqsy4v5aca5nd-goreleaser-2.9.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/r879776j6ymhyd3fg1jlqsy4v5aca5nd-goreleaser-2.9.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/iibmw8lki8rf2kanzpg6c6n9llfq1737-goreleaser-2.9.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/iibmw8lki8rf2kanzpg6c6n9llfq1737-goreleaser-2.9.0"
+        }
+      }
+    }
+  }
+}

--- a/perplexity.go
+++ b/perplexity.go
@@ -82,7 +82,7 @@ func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *Comp
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.endpoint, bytes.NewBuffer(requestBody))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -145,7 +145,7 @@ func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.Wai
 		return fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.endpoint, bytes.NewBuffer(requestBody))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/perplexity.go
+++ b/perplexity.go
@@ -24,8 +24,6 @@ const DefaultTimeout = 30 * time.Second
 // DefaultModel is the default model for the Perplexity API.
 const DefaultModel = "sonar"
 
-const defaultSizeSSEResponse = 64000
-
 // Client is a client for the Perplexity API.
 type Client struct {
 	endpoint   string
@@ -125,7 +123,7 @@ func (s *Client) SendSSEHTTPRequest(wg *sync.WaitGroup, req *CompletionRequest, 
 // SendSSEHTTPRequestWithContext sends a completion request to the Perplexity API using Server-Sent Events with the given context.
 // It writes each response (event) on the provided responseChannel.
 // The channel will be closed when the request is done.
-func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error {
+func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error { //nolint:gocognit,cyclop
 	if responseChannel == nil {
 		return fmt.Errorf("responseChannel must not be nil")
 	}
@@ -192,7 +190,7 @@ func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.Wai
 		}
 
 		// Check if this is a data line
-		if bytes.HasPrefix(line, []byte("data: ")) {
+		if bytes.HasPrefix(line, []byte("data: ")) { //nolint:nestif
 			// Remove the "data: " prefix
 			data := bytes.TrimPrefix(line, []byte("data: "))
 			data = bytes.TrimSpace(data)

--- a/perplexity.go
+++ b/perplexity.go
@@ -109,11 +109,10 @@ func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *Comp
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-	err = json.Unmarshal(body, r)
-	if err != nil {
+	if err := json.Unmarshal(body, r); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response body: %w - body response=%s", err, string(body))
 	}
-	return r, err
+	return r, nil
 }
 
 // SendSSEHTTPRequest sends a completion request to the Perplexity API using Server-Sent Events.

--- a/perplexity.go
+++ b/perplexity.go
@@ -3,6 +3,7 @@ package perplexity
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -66,6 +67,11 @@ func (s *Client) GetHTTPTimeout() time.Duration {
 
 // SendCompletionRequest sends a completion request to the Perplexity API.
 func (s *Client) SendCompletionRequest(req *CompletionRequest) (*CompletionResponse, error) {
+	return s.SendCompletionRequestWithContext(context.Background(), req)
+}
+
+// SendCompletionRequest sends a completion request to the Perplexity API.
+func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
 	r := &CompletionResponse{}
 	if req == nil {
 		return nil, fmt.Errorf("request must not be nil")
@@ -74,7 +80,7 @@ func (s *Client) SendCompletionRequest(req *CompletionRequest) (*CompletionRespo
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)
 	}
-	httpReq, err := http.NewRequest("POST", s.endpoint, bytes.NewBuffer(requestBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.endpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -112,6 +118,13 @@ func (s *Client) SendCompletionRequest(req *CompletionRequest) (*CompletionRespo
 // It writes each response (event) on the channel responseChannel
 // The channel will be closed when the request is done.
 func (s *Client) SendSSEHTTPRequest(wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error {
+	return s.SendSSEHTTPRequestWithContext(context.Background(), wg, req, responseChannel)
+}
+
+// SendSSEHTTPRequest sends a completion request to the Perplexity API using Server-Sent Events.
+// It writes each response (event) on the channel responseChannel
+// The channel will be closed when the request is done.
+func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error {
 	if responseChannel == nil {
 		return fmt.Errorf("responseChannel must not be nil")
 	}
@@ -130,7 +143,7 @@ func (s *Client) SendSSEHTTPRequest(wg *sync.WaitGroup, req *CompletionRequest, 
 		return fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", s.endpoint, bytes.NewBuffer(requestBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.endpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/perplexity.go
+++ b/perplexity.go
@@ -24,6 +24,18 @@ const DefaultTimeout = 30 * time.Second
 // DefaultModel is the default model for the Perplexity API.
 const DefaultModel = "sonar"
 
+// Error definitions.
+var (
+	// ErrNilRequest is returned when a nil request is provided.
+	ErrNilRequest = errors.New("request must not be nil")
+	// ErrUnauthorized is returned when the API key is invalid or missing.
+	ErrUnauthorized = errors.New("unauthorized: check your API key")
+	// ErrNilResponseChannel is returned when a nil response channel is provided.
+	ErrNilResponseChannel = errors.New("response channel must not be nil")
+	// ErrNilWaitGroup is returned when a nil wait group is provided.
+	ErrNilWaitGroup = errors.New("wait group must not be nil")
+)
+
 // Client is a client for the Perplexity API.
 type Client struct {
 	endpoint   string
@@ -74,7 +86,7 @@ func (s *Client) SendCompletionRequest(req *CompletionRequest) (*CompletionRespo
 func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
 	r := &CompletionResponse{}
 	if req == nil {
-		return nil, fmt.Errorf("request must not be nil")
+		return nil, ErrNilRequest
 	}
 	requestBody, err := json.Marshal(req)
 	if err != nil {
@@ -95,7 +107,7 @@ func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *Comp
 	// Check return status code
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, fmt.Errorf("unauthorized: check your API key")
+			return nil, ErrUnauthorized
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -125,13 +137,13 @@ func (s *Client) SendSSEHTTPRequest(wg *sync.WaitGroup, req *CompletionRequest, 
 // The channel will be closed when the request is done.
 func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error { //nolint:gocognit,cyclop
 	if responseChannel == nil {
-		return fmt.Errorf("responseChannel must not be nil")
+		return ErrNilResponseChannel
 	}
 	if wg == nil {
-		return fmt.Errorf("wg must not be nil")
+		return ErrNilWaitGroup
 	}
 	if req == nil {
-		return fmt.Errorf("request must not be nil")
+		return ErrNilRequest
 	}
 
 	defer close(responseChannel)
@@ -161,7 +173,7 @@ func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.Wai
 
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusUnauthorized {
-			return fmt.Errorf("unauthorized: check your API key")
+			return ErrUnauthorized
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/perplexity.go
+++ b/perplexity.go
@@ -1,3 +1,5 @@
+// Package perplexity provides a Go client for interacting with the Perplexity AI API.
+// It supports both synchronous and streaming (SSE) completion requests.
 package perplexity
 
 import (
@@ -70,7 +72,7 @@ func (s *Client) SendCompletionRequest(req *CompletionRequest) (*CompletionRespo
 	return s.SendCompletionRequestWithContext(context.Background(), req)
 }
 
-// SendCompletionRequest sends a completion request to the Perplexity API.
+// SendCompletionRequestWithContext sends a completion request to the Perplexity API with the given context.
 func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
 	r := &CompletionResponse{}
 	if req == nil {
@@ -121,8 +123,8 @@ func (s *Client) SendSSEHTTPRequest(wg *sync.WaitGroup, req *CompletionRequest, 
 	return s.SendSSEHTTPRequestWithContext(context.Background(), wg, req, responseChannel)
 }
 
-// SendSSEHTTPRequest sends a completion request to the Perplexity API using Server-Sent Events.
-// It writes each response (event) on the channel responseChannel
+// SendSSEHTTPRequestWithContext sends a completion request to the Perplexity API using Server-Sent Events with the given context.
+// It writes each response (event) on the provided responseChannel.
 // The channel will be closed when the request is done.
 func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error {
 	if responseChannel == nil {

--- a/perplexity_error.go
+++ b/perplexity_error.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 )
 
-// ErrorResponse is an error response object for the Perplexity API.
-type ErrorResponse struct {
+// ResponseError is an error response object for the Perplexity API.
+type ResponseError struct {
 	ErrorData struct {
 		Message string `json:"message"`
 		Type    string `json:"type"`
@@ -14,8 +14,8 @@ type ErrorResponse struct {
 	} `json:"error"`
 }
 
-// Error returns the error message of the ErrorResponse.
-func (r *ErrorResponse) Error() string {
+// Error returns the error message of the ResponseError.
+func (r *ResponseError) Error() string {
 	if r == nil {
 		return ""
 	}
@@ -25,7 +25,7 @@ func (r *ErrorResponse) Error() string {
 // ParseErrorMessage unmarshals a []byte representing an API error response
 // and returns the error message.
 func ParseErrorMessage(data []byte) error {
-	var errResp ErrorResponse
+	var errResp ResponseError
 	if err := json.Unmarshal(data, &errResp); err != nil {
 		return fmt.Errorf("failed to unmarshal error response: %w", err)
 	}

--- a/perplexity_error_test.go
+++ b/perplexity_error_test.go
@@ -12,19 +12,19 @@ func TestParseErrorMessage(t *testing.T) {
 			t.Fatalf("expected an error, got nil")
 		}
 
-		errorResponse, ok := err.(*ErrorResponse)
+		responseError, ok := err.(*ResponseError)
 		if !ok {
-			t.Fatalf("expected error of type *ErrorResponse, got %T", err)
+			t.Fatalf("expected error of type *ResponseError, got %T", err)
 		}
 
-		if errorResponse.ErrorData.Message != "An error occurred" {
-			t.Errorf("expected message 'An error occurred', got '%s'", errorResponse.ErrorData.Message)
+		if responseError.ErrorData.Message != "An error occurred" {
+			t.Errorf("expected message 'An error occurred', got '%s'", responseError.ErrorData.Message)
 		}
-		if errorResponse.ErrorData.Type != "APIError" {
-			t.Errorf("expected type 'APIError', got '%s'", errorResponse.ErrorData.Type)
+		if responseError.ErrorData.Type != "APIError" {
+			t.Errorf("expected type 'APIError', got '%s'", responseError.ErrorData.Type)
 		}
-		if errorResponse.ErrorData.Code != 400 {
-			t.Errorf("expected code 400, got %d", errorResponse.ErrorData.Code)
+		if responseError.ErrorData.Code != 400 {
+			t.Errorf("expected code 400, got %d", responseError.ErrorData.Code)
 		}
 	})
 

--- a/perplexity_error_test.go
+++ b/perplexity_error_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestParseErrorMessage(t *testing.T) {
-	t.Run("ValidErrorResponse", func(t *testing.T) {
+	t.Run("ValidResponseError", func(t *testing.T) {
 		data := []byte(`{"error": {"message": "An error occurred", "type": "APIError", "code": 400}}`)
 		err := ParseErrorMessage(data)
 		if err == nil {
@@ -35,8 +35,8 @@ func TestParseErrorMessage(t *testing.T) {
 			t.Fatalf("expected an error, got nil")
 		}
 
-		if _, ok := err.(*ErrorResponse); ok {
-			t.Fatalf("expected a JSON unmarshal error, got *ErrorResponse")
+		if _, ok := err.(*ResponseError); ok {
+			t.Fatalf("expected a JSON unmarshal error, got *ResponseError")
 		}
 	})
 
@@ -47,8 +47,8 @@ func TestParseErrorMessage(t *testing.T) {
 			t.Fatalf("expected an error, got nil")
 		}
 
-		if _, ok := err.(*ErrorResponse); ok {
-			t.Fatalf("expected a JSON unmarshal error, got *ErrorResponse")
+		if _, ok := err.(*ResponseError); ok {
+			t.Fatalf("expected a JSON unmarshal error, got *ResponseError")
 		}
 	})
 
@@ -59,8 +59,8 @@ func TestParseErrorMessage(t *testing.T) {
 			t.Fatalf("expected an error, got nil")
 		}
 
-		if _, ok := err.(*ErrorResponse); ok {
-			t.Fatalf("expected a JSON unmarshal error, got *ErrorResponse")
+		if _, ok := err.(*ResponseError); ok {
+			t.Fatalf("expected a JSON unmarshal error, got *ResponseError")
 		}
 	})
 }

--- a/perplexity_msg.go
+++ b/perplexity_msg.go
@@ -1,6 +1,16 @@
 package perplexity
 
-import "fmt"
+import "errors"
+
+// Error definitions.
+var (
+	// ErrPrevMessageShouldBeAssistant is returned when the previous message is not from the assistant.
+	ErrPrevMessageShouldBeAssistant = errors.New("previous message should be an assistant message")
+	// ErrFirstMessageShouldBeUser is returned when the first message is not from the user.
+	ErrFirstMessageShouldBeUser = errors.New("first message should be a user message")
+	// ErrPrevMessageShouldBeUser is returned when the previous message is not from the user.
+	ErrPrevMessageShouldBeUser = errors.New("previous message should be a user message")
+)
 
 // Message is a message object for the Perplexity API.
 type Message struct {
@@ -38,7 +48,7 @@ func (m *Messages) AddUserMessage(content string) error {
 	if len(m.messages) > 0 {
 		// Previous message should be an assistant message.
 		if m.messages[len(m.messages)-1].Role != "assistant" {
-			return fmt.Errorf("previous message should be an assistant message")
+			return ErrPrevMessageShouldBeAssistant
 		}
 	}
 	m.messages = append(m.messages, Message{
@@ -52,11 +62,11 @@ func (m *Messages) AddUserMessage(content string) error {
 func (m *Messages) AddAgentMessage(content string) error {
 	if len(m.messages) == 0 {
 		// First message should be a user message.
-		return fmt.Errorf("first message should be a user message")
+		return ErrFirstMessageShouldBeUser
 	}
 	// Previous message should be a user message.
 	if m.messages[len(m.messages)-1].Role != "user" {
-		return fmt.Errorf("previous message should be a user message")
+		return ErrPrevMessageShouldBeUser
 	}
 	m.messages = append(m.messages, Message{
 		Role:    "assistant",

--- a/perplexity_msg.go
+++ b/perplexity_msg.go
@@ -65,6 +65,8 @@ func (m *Messages) AddAgentMessage(content string) error {
 	return nil
 }
 
+// GetMessages returns all messages including the system message (if any) as a slice of Message.
+// The system message is always included as the first message when present.
 func (m *Messages) GetMessages() []Message {
 	var result []Message
 	// system message is added in the first position

--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -2,6 +2,7 @@ package perplexity
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/go-playground/validator/v10"
 )
@@ -308,9 +309,8 @@ func NewCompletionRequest(opts ...CompletionRequestOption) *CompletionRequest {
 // Validate validates the completion request.
 func (r *CompletionRequest) Validate() error {
 	validate := validator.New()
-	err := validate.Struct(r)
-	if err != nil {
-		return err
+	if err := validate.Struct(r); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
 	}
 	if err := r.ValidateSearchDomainFilter(); err != nil {
 		return err

--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -6,18 +6,35 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+// ErrSearchDomainFilter is returned when the search domain filter exceeds the maximum allowed number of domains.
 var ErrSearchDomainFilter = errors.New("search domain filter must be less than or equal to 3")
+
+// ErrSearchRecencyFilter is returned when the search recency filter is incompatible with image search.
 var ErrSearchRecencyFilter = errors.New("search recency filter is incompatible with images")
 
 const (
-	DefaultTemperature         = 0.2
-	DefaultTopP                = 0.9
-	DefaultTopK                = 0
-	DefaultMaxTokens           = 4000
-	DefaultPresencePenalty     = 0.0
-	DefaultFrequencyPenalty    = 1.0
+	// DefaultTemperature is the default temperature value for text generation (0.0 to 1.0).
+	DefaultTemperature = 0.2
+
+	// DefaultTopP is the default top-p sampling parameter (0.0 to 1.0).
+	DefaultTopP = 0.9
+
+	// DefaultTopK is the default top-k sampling parameter (0 to 2048).
+	DefaultTopK = 0
+
+	// DefaultMaxTokens is the default maximum number of tokens to generate.
+	DefaultMaxTokens = 4000
+
+	// DefaultPresencePenalty is the default presence penalty value (-2.0 to 2.0).
+	DefaultPresencePenalty = 0.0
+
+	// DefaultFrequencyPenalty is the default frequency penalty value (0.0 to 1.0).
+	DefaultFrequencyPenalty = 1.0
+
+	// DefaultSearchRecencyFilter is the default search recency filter value.
 	DefaultSearchRecencyFilter = "month"
 
+	// MaxLengthOfSearchDomainFilter is the maximum number of domains allowed in the search domain filter.
 	MaxLengthOfSearchDomainFilter = 3
 )
 
@@ -193,7 +210,7 @@ func WithModel(model string) CompletionRequestOption {
 	}
 }
 
-// WithModelDefaultModel sets the model to sonar.
+// WithDefaultModel sets the model to the default sonar model.
 func WithDefaultModel() CompletionRequestOption {
 	return func(r *CompletionRequest) {
 		r.Model = DefaultModel

--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -257,8 +257,8 @@ func WithTopK(topK int) CompletionRequestOption {
 }
 
 // WithStream sets the stream option.
-// Determines whether or not to incrementally stream the response
-// with server-sent events with content-type: text/event-stream
+// Determines whether or not to incrementally stream the response.
+// with server-sent events with content-type: text/event-stream.
 func WithStream(stream bool) CompletionRequestOption {
 	return func(r *CompletionRequest) {
 		r.Stream = stream

--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -10,8 +10,8 @@ import (
 // ErrSearchDomainFilter is returned when the search domain filter exceeds the maximum allowed number of domains.
 var ErrSearchDomainFilter = errors.New("search domain filter must be less than or equal to 3")
 
-// ErrSearchRecencyFilter is returned when the search recency filter is incompatible with image search.
-var ErrSearchRecencyFilter = errors.New("search recency filter is incompatible with images")
+// ErrSearchRecencyFilter is returned when the search recency filter is invalid or incompatible.
+var ErrSearchRecencyFilter = errors.New("search recency filter must be one of month, week, day, hour and is incompatible with images")
 
 const (
 	// DefaultTemperature is the default temperature value for text generation (0.0 to 1.0).
@@ -339,7 +339,7 @@ func (r *CompletionRequest) ValidateSearchRecencyFilter() error {
 		case "month", "week", "day", "hour":
 			return nil
 		default:
-			return errors.New("search recency filter must be one of month, week, day, hour")
+			return ErrSearchRecencyFilter
 		}
 	}
 	return nil

--- a/perplexity_test.go
+++ b/perplexity_test.go
@@ -43,7 +43,7 @@ func TestGetCompletion(t *testing.T) {
 		ts := httptest.NewTLSServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Check the request
-				assert.Equal(t, r.Method, "POST")
+				assert.Equal(t, r.Method, http.MethodPost)
 				assert.Equal(t, r.Header.Get("Authorization"), "Bearer "+apiKey)
 				assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
 				defer r.Body.Close()
@@ -124,7 +124,7 @@ func TestSendSSEHTTPRequest(t *testing.T) {
 		ts := httptest.NewTLSServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Check the headers
-				assert.Equal(t, r.Method, "POST")
+				assert.Equal(t, r.Method, http.MethodPost)
 				assert.Equal(t, r.Header.Get("Authorization"), "Bearer "+apiKey)
 				assert.Equal(t, r.Header.Get("Cache-Control"), "no-cache")
 				assert.Equal(t, r.Header.Get("Accept"), "text/event-stream")


### PR DESCRIPTION
- **chore: add linting configuration and improve code documentation**
  

- **feat: add context support to Perplexity API client methods**
  

- **docs: add package documentation and improve function comments**
  

- **chore: disable errcheck and tagliatelle linters to golangci configuration**
  

- **refactor: replace hardcoded POST strings with http.MethodPost constant**
  

- **refactor: rename ErrorResponse to ResponseError for better clarity**
  

- **refactor: rename ErrorResponse to ResponseError for consistency in error handling tests**
  

- **chore: improve error handling and add golangci-lint rules for line length and function length**
  

- **chore: disable linter warnings and remove unused constant**
  

- **chore: disable tagalign linter and exclude cmd directory from linting**
  

- **refactor: standardize error handling with predefined error variables across package**
  

- **feat: add golangci-lint workflow and devbox configuration**
  