### PR TITLE
Feat: Add support for search_results in completionRequest

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,11 +67,17 @@ func main() {
 			fmt.Printf("%d. %s\n", i+1, c)
 		}
 	}
+	if len(res.GetSearchResults()) > 0 {
+		fmt.Println("\n=== Search Results ===")
+		for i, sr := range res.GetSearchResults() {
+			fmt.Printf("%d. %s\n", i+1, sr.String())
+		}
+	}
 	fmt.Println("*************")
 
 	// Example of structured output with JSON Schema
 	fmt.Println("\n=== JSON Schema Structured Output Example ===")
-	
+
 	// Define a JSON schema for structured response
 	personSchema := map[string]interface{}{
 		"type": "object",

--- a/perplexity_response.go
+++ b/perplexity_response.go
@@ -22,13 +22,44 @@ type Choice struct {
 
 // CompletionResponse is a response object for the Perplexity API.
 type CompletionResponse struct {
-	ID        string    `json:"id"`
-	Model     string    `json:"model"`
-	Created   int       `json:"created"`
-	Usage     Usage     `json:"usage"`
-	Object    string    `json:"object"`
-	Choices   []Choice  `json:"choices"`
+	ID            string          `json:"id"`
+	Model         string          `json:"model"`
+	Created       int             `json:"created"`
+	Usage         Usage           `json:"usage"`
+	Object        string          `json:"object"`
+	Choices       []Choice        `json:"choices"`
+	SearchResults *[]SearchResult `json:"search_results,omitempty"`
+	// Deprecated: Use SearchResults instead for better structured data with titles, URLs, and metadata.
+	//go:deprecated
 	Citations *[]string `json:"citations,omitempty"`
+}
+
+// SearchResult represents a single search result in the Perplexity API response.
+type SearchResult struct {
+	Title       string  `json:"title"`
+	URL         string  `json:"url"`
+	Date        *string `json:"date,omitempty"`
+	LastUpdated *string `json:"last_updated,omitempty"`
+}
+
+// String returns a string representation of the SearchResult.
+func (sr *SearchResult) String() string {
+	if sr == nil {
+		return ""
+	}
+
+	result := sr.Title
+	if sr.URL != "" {
+		result += " (" + sr.URL + ")"
+	}
+	if sr.Date != nil {
+		result += " - " + *sr.Date
+	}
+	if sr.LastUpdated != nil {
+		result += " (updated: " + *sr.LastUpdated + ")"
+	}
+
+	return result
 }
 
 // String returns a string representation of the CompletionResponse.
@@ -55,9 +86,20 @@ func (r *CompletionResponse) GetLastContent() string {
 }
 
 // GetCitations returns the citations of the completion response.
+// Deprecated: Use GetSearchResults instead for better structured data with titles, URLs, and metadata.
+//
+//go:deprecated
 func (r *CompletionResponse) GetCitations() []string {
 	if r.Citations == nil {
 		return []string{}
 	}
 	return *r.Citations
+}
+
+// GetSearchResults returns the search results of the completion response.
+func (r *CompletionResponse) GetSearchResults() []SearchResult {
+	if r.SearchResults == nil {
+		return []SearchResult{}
+	}
+	return *r.SearchResults
 }

--- a/perplexity_response_test.go
+++ b/perplexity_response_test.go
@@ -99,3 +99,91 @@ func TestGetCitations(t *testing.T) {
 		assert.Equal(t, content.GetCitations(), []string{"citation1", "citation2"})
 	})
 }
+
+func TestGetSearchResults(t *testing.T) {
+	t.Run("empty response returns empty search results", func(t *testing.T) {
+		content := perplexity.CompletionResponse{}
+		assert.Equal(t, content.GetSearchResults(), []perplexity.SearchResult{})
+	})
+
+	t.Run("nil search results returns empty search results", func(t *testing.T) {
+		content := perplexity.CompletionResponse{
+			SearchResults: nil,
+		}
+		assert.Equal(t, content.GetSearchResults(), []perplexity.SearchResult{})
+	})
+
+	t.Run("case with real search results", func(t *testing.T) {
+		searchResults := []perplexity.SearchResult{
+			{
+				Title: "Test Article 1",
+				URL:   "https://example.com/article1",
+				Date:  stringPtr("2024-01-01"),
+			},
+			{
+				Title:       "Test Article 2",
+				URL:         "https://example.com/article2",
+				LastUpdated: stringPtr("2024-01-02"),
+			},
+		}
+		content := perplexity.CompletionResponse{
+			SearchResults: &searchResults,
+		}
+		assert.Equal(t, content.GetSearchResults(), searchResults)
+	})
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestSearchResultString(t *testing.T) {
+	t.Run("nil search result returns empty string", func(t *testing.T) {
+		var sr *perplexity.SearchResult
+		assert.Equal(t, "", sr.String())
+	})
+
+	t.Run("search result with title only", func(t *testing.T) {
+		sr := &perplexity.SearchResult{
+			Title: "Test Article",
+		}
+		assert.Equal(t, "Test Article", sr.String())
+	})
+
+	t.Run("search result with title and URL", func(t *testing.T) {
+		sr := &perplexity.SearchResult{
+			Title: "Test Article",
+			URL:   "https://example.com/article",
+		}
+		assert.Equal(t, "Test Article (https://example.com/article)", sr.String())
+	})
+
+	t.Run("search result with title, URL, and date", func(t *testing.T) {
+		sr := &perplexity.SearchResult{
+			Title: "Test Article",
+			URL:   "https://example.com/article",
+			Date:  stringPtr("2024-01-01"),
+		}
+		assert.Equal(t, "Test Article (https://example.com/article) - 2024-01-01", sr.String())
+	})
+
+	t.Run("search result with title, URL, and last updated", func(t *testing.T) {
+		sr := &perplexity.SearchResult{
+			Title:       "Test Article",
+			URL:         "https://example.com/article",
+			LastUpdated: stringPtr("2024-01-02"),
+		}
+		assert.Equal(t, "Test Article (https://example.com/article) (updated: 2024-01-02)", sr.String())
+	})
+
+	t.Run("search result with all fields", func(t *testing.T) {
+		sr := &perplexity.SearchResult{
+			Title:       "Test Article",
+			URL:         "https://example.com/article",
+			Date:        stringPtr("2024-01-01"),
+			LastUpdated: stringPtr("2024-01-02"),
+		}
+		assert.Equal(t, "Test Article (https://example.com/article) - 2024-01-01 (updated: 2024-01-02)", sr.String())
+	})
+}


### PR DESCRIPTION
Search_results were recently added and are improved citations with more information

Citations are being deprecated in favour of search_results.

see: https://docs.perplexity.ai/changelog/changelog , June 2025

We have added support for search_results and marked the citations as deprecated.