### PR TITLE
feat: add support for image filters to CompletionRequest and Images to CompleteResponse

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/main.go",
-      // "env": {
-      //     "DBDSN": "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
-      // },
+      "env": {
+        "PPLX_API_KEY": "{YOUR_PERPLEXITY_API_KEY}"
+      },
       "args": []
     }
   ]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,21 +12,22 @@ import (
 // This example demonstrates how to create a completion request with web search options.
 func main() {
 	client := perplexity.NewClient(os.Getenv("PPLX_API_KEY"))
+	validator := perplexity.NewRequestValidator()
 
-	demonstrateBaseCompletion(client)
+	demonstrateBaseCompletion(client, validator)
 	printBreakToConsole()
 
-	demonstrateCompletionWithStructuredOutput(client)
+	demonstrateCompletionWithStructuredOutput(client, validator)
 	printBreakToConsole()
 
-	demonstrateCompletionWithImages(client)
+	demonstrateCompletionWithImages(client, validator)
 	printBreakToConsole()
 
-	demonstrateCompletionWithServerSentEvents(client)
+	demonstrateCompletionWithServerSentEvents(client, validator)
 
 }
 
-func demonstrateBaseCompletion(client *perplexity.Client) {
+func demonstrateBaseCompletion(client *perplexity.Client, validator *perplexity.RequestValidator) {
 	// Example message that would benefit from web search
 	msg := []perplexity.Message{
 		{
@@ -59,7 +60,7 @@ func demonstrateBaseCompletion(client *perplexity.Client) {
 	// )
 
 	// Validate the request
-	if err := perplexity.NewRequestValidator().ValidateRequest(req); err != nil {
+	if err := validator.ValidateRequest(req); err != nil {
 		fmt.Printf("Validation error: %v\n", err)
 		os.Exit(1)
 	}
@@ -88,10 +89,9 @@ func demonstrateBaseCompletion(client *perplexity.Client) {
 		}
 	}
 	fmt.Println(res.GetImages())
-	fmt.Println("*************")
 }
 
-func demonstrateCompletionWithStructuredOutput(client *perplexity.Client) {
+func demonstrateCompletionWithStructuredOutput(client *perplexity.Client, validator *perplexity.RequestValidator) {
 
 	// Example of structured output with JSON Schema
 	fmt.Println("\n=== JSON Schema Structured Output Example ===")
@@ -130,7 +130,7 @@ func demonstrateCompletionWithStructuredOutput(client *perplexity.Client) {
 		perplexity.WithJSONSchemaResponseFormat(personSchema),
 	)
 
-	if err := perplexity.NewRequestValidator().ValidateRequest(structuredReq); err != nil {
+	if err := validator.ValidateRequest(structuredReq); err != nil {
 		fmt.Printf("Structured request validation error: %v\n", err)
 		os.Exit(1)
 	}
@@ -161,7 +161,7 @@ func demonstrateCompletionWithStructuredOutput(client *perplexity.Client) {
 		perplexity.WithRegexResponseFormat(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`),
 	)
 
-	if err := perplexity.NewRequestValidator().ValidateRequest(regexReq); err != nil {
+	if err := validator.ValidateRequest(regexReq); err != nil {
 		fmt.Printf("Regex request validation error: %v\n", err)
 		os.Exit(1)
 	}
@@ -174,10 +174,9 @@ func demonstrateCompletionWithStructuredOutput(client *perplexity.Client) {
 
 	fmt.Println("Regex Response:")
 	fmt.Println(regexRes.GetLastContent())
-	fmt.Println("*************")
 }
 
-func demonstrateCompletionWithImages(client *perplexity.Client) {
+func demonstrateCompletionWithImages(client *perplexity.Client, validator *perplexity.RequestValidator) {
 	msg := []perplexity.Message{
 		{
 			Role:    "user",
@@ -191,7 +190,7 @@ func demonstrateCompletionWithImages(client *perplexity.Client) {
 		perplexity.WithReturnImages(true),
 	)
 
-	if err := perplexity.NewRequestValidator().ValidateRequest(req); err != nil {
+	if err := validator.ValidateRequest(req); err != nil {
 		fmt.Printf("Images request validation error: %v\n", err)
 		os.Exit(1)
 	}
@@ -206,11 +205,10 @@ func demonstrateCompletionWithImages(client *perplexity.Client) {
 	for _, img := range imagesRes.GetImages() {
 		fmt.Println(img.String())
 	}
-	fmt.Println("*************")
 }
 
 // Support also server-sent events
-func demonstrateCompletionWithServerSentEvents(client *perplexity.Client) {
+func demonstrateCompletionWithServerSentEvents(client *perplexity.Client, validator *perplexity.RequestValidator) {
 
 	msg := []perplexity.Message{
 		{
@@ -219,7 +217,7 @@ func demonstrateCompletionWithServerSentEvents(client *perplexity.Client) {
 		},
 	}
 	req := perplexity.NewCompletionRequest(perplexity.WithMessages(msg), perplexity.WithStream(true))
-	err := perplexity.NewRequestValidator().ValidateRequest(req)
+	err := validator.ValidateRequest(req)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,20 @@ import (
 func main() {
 	client := perplexity.NewClient(os.Getenv("PPLX_API_KEY"))
 
+	demonstrateBaseCompletion(client)
+	printBreakToConsole()
+
+	demonstrateCompletionWithStructuredOutput(client)
+	printBreakToConsole()
+
+	demonstrateCompletionWithImages(client)
+	printBreakToConsole()
+
+	demonstrateCompletionWithServerSentEvents(client)
+
+}
+
+func demonstrateBaseCompletion(client *perplexity.Client) {
 	// Example message that would benefit from web search
 	msg := []perplexity.Message{
 		{
@@ -45,7 +59,7 @@ func main() {
 	// )
 
 	// Validate the request
-	if err := req.Validate(); err != nil {
+	if err := perplexity.NewRequestValidator().ValidateRequest(req); err != nil {
 		fmt.Printf("Validation error: %v\n", err)
 		os.Exit(1)
 	}
@@ -73,7 +87,11 @@ func main() {
 			fmt.Printf("%d. %s\n", i+1, sr.String())
 		}
 	}
+	fmt.Println(res.GetImages())
 	fmt.Println("*************")
+}
+
+func demonstrateCompletionWithStructuredOutput(client *perplexity.Client) {
 
 	// Example of structured output with JSON Schema
 	fmt.Println("\n=== JSON Schema Structured Output Example ===")
@@ -97,70 +115,111 @@ func main() {
 		},
 		"required": []string{"name", "age", "profession"},
 	}
-	
+
 	structuredMsg := []perplexity.Message{
 		{
 			Role:    "user",
 			Content: "Tell me about Albert Einstein. Please format your response as a JSON object with name, age at death, and profession.",
 		},
 	}
-	
+
 	// Create a request with JSON schema structured output
 	structuredReq := perplexity.NewCompletionRequest(
 		perplexity.WithMessages(structuredMsg),
 		perplexity.WithModel("sonar"), // Note: structured output only works with "sonar" model
 		perplexity.WithJSONSchemaResponseFormat(personSchema),
 	)
-	
-	if err := structuredReq.Validate(); err != nil {
+
+	if err := perplexity.NewRequestValidator().ValidateRequest(structuredReq); err != nil {
 		fmt.Printf("Structured request validation error: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	structuredRes, err := client.SendCompletionRequest(structuredReq)
 	if err != nil {
 		fmt.Printf("Structured API error: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	fmt.Println("JSON Schema Response:")
 	fmt.Println(structuredRes.GetLastContent())
-	
+
 	// Example of structured output with Regex
 	fmt.Println("\n=== Regex Structured Output Example ===")
-	
+
 	regexMsg := []perplexity.Message{
 		{
 			Role:    "user",
 			Content: "What is the IP address of Google's primary DNS server? Please respond with just the IP address in the format x.x.x.x",
 		},
 	}
-	
+
 	// Create a request with regex structured output for IP addresses
 	regexReq := perplexity.NewCompletionRequest(
 		perplexity.WithMessages(regexMsg),
 		perplexity.WithModel("sonar"),
 		perplexity.WithRegexResponseFormat(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`),
 	)
-	
-	if err := regexReq.Validate(); err != nil {
+
+	if err := perplexity.NewRequestValidator().ValidateRequest(regexReq); err != nil {
 		fmt.Printf("Regex request validation error: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	regexRes, err := client.SendCompletionRequest(regexReq)
 	if err != nil {
 		fmt.Printf("Regex API error: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	fmt.Println("Regex Response:")
 	fmt.Println(regexRes.GetLastContent())
 	fmt.Println("*************")
+}
 
-	// Support also server-sent events
-	req = perplexity.NewCompletionRequest(perplexity.WithMessages(msg), perplexity.WithStream(true))
-	err = req.Validate()
+func demonstrateCompletionWithImages(client *perplexity.Client) {
+	msg := []perplexity.Message{
+		{
+			Role:    "user",
+			Content: "Find some photos of the Eiffel Tower",
+		},
+	}
+
+	req := perplexity.NewCompletionRequest(
+		perplexity.WithMessages(msg),
+		perplexity.WithSearchRecencyFilter(""),
+		perplexity.WithReturnImages(true),
+	)
+
+	if err := perplexity.NewRequestValidator().ValidateRequest(req); err != nil {
+		fmt.Printf("Images request validation error: %v\n", err)
+		os.Exit(1)
+	}
+
+	imagesRes, err := client.SendCompletionRequest(req)
+	if err != nil {
+		fmt.Printf("Images API error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Images Response:")
+	for _, img := range imagesRes.GetImages() {
+		fmt.Println(img.String())
+	}
+	fmt.Println("*************")
+}
+
+// Support also server-sent events
+func demonstrateCompletionWithServerSentEvents(client *perplexity.Client) {
+
+	msg := []perplexity.Message{
+		{
+			Role:    "user",
+			Content: "What are the latest developments in AI?",
+		},
+	}
+	req := perplexity.NewCompletionRequest(perplexity.WithMessages(msg), perplexity.WithStream(true))
+	err := perplexity.NewRequestValidator().ValidateRequest(req)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
@@ -185,12 +244,15 @@ func main() {
 	for msg := range chResponses {
 		fullResponse = msg
 	}
-	// perplexity.TreatSSEData(chResponses)
+
 	wg.Wait()
 	fmt.Println("----------------")
 	fmt.Println(fullResponse.GetLastContent())
-	// if err != nil {
-	// 	fmt.Printf("Error: %v\n", err)
-	// 	os.Exit(1)
-	// }
+}
+
+// printBreakToConsole prints a visual break in the console output for readability.
+func printBreakToConsole() {
+	fmt.Println()
+	fmt.Println("*************")
+	fmt.Println()
 }

--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -21,9 +21,6 @@ const (
 
 	// DefaultSearchRecencyFilter is the default search recency filter value.
 	DefaultSearchRecencyFilter = "month"
-
-	// MaxLengthOfSearchDomainFilter is the maximum number of domains allowed in the search domain filter.
-	MaxLengthOfSearchDomainFilter = 3
 )
 
 // CompletionRequest is a request object for the Perplexity API.
@@ -49,8 +46,8 @@ type CompletionRequest struct {
 	// Required range: 0 < x < 1
 	TopP float64 `json:"top_p" validate:"gt=0,lt=1"`
 	// SearchDomainFilter: Given a list of domains, limit the citations used by the online model
-	// to URLs from the specified domains. Currently limited to only 3 domains for whitelisting and blacklisting.
-	// For blacklisting add a - to the beginning of the domain string. This filter is in closed beta
+	// to URLs from the specified domains. Currently limited to only 3 domains for allowlisting and denylisting.
+	// For denylisting add a - to the beginning of the domain string. This filter is in closed beta
 	SearchDomainFilter []string `json:"search_domain_filter"`
 	// ReturnImages: Determines whether or not a request to an online model
 	// should return images. Images are in closed beta

--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -1,27 +1,5 @@
 package perplexity
 
-import (
-	"errors"
-	"fmt"
-
-	"github.com/go-playground/validator/v10"
-)
-
-// ErrSearchDomainFilter is returned when the search domain filter exceeds the maximum allowed number of domains.
-var ErrSearchDomainFilter = errors.New("search domain filter must be less than or equal to 3")
-
-// ErrSearchRecencyFilter is returned when the search recency filter is invalid or incompatible.
-var ErrSearchRecencyFilter = errors.New("search recency filter must be one of month, week, day, hour and is incompatible with images")
-
-// ErrStructuredOutputModelRequirement is returned when structured output is used with a model other than "sonar".
-var ErrStructuredOutputModelRequirement = errors.New("structured output (response_format) is only available for the 'sonar' model")
-
-// ErrStructuredOutputFormatMismatch is returned when the response format type doesn't match the provided configuration.
-var ErrStructuredOutputFormatMismatch = errors.New("response format type must match the provided configuration (json_schema or regex)")
-
-// ErrStructuredOutputRegexAndImages is returned when regex and images are used together.
-var ErrStructuredOutputRegexAndImages = errors.New("regex and images are not compatible")
-
 const (
 	// DefaultTemperature is the default temperature value for text generation (0.0 to 1.0).
 	DefaultTemperature = 0.2
@@ -111,6 +89,25 @@ type CompletionRequest struct {
 	// Supports JSON Schema and Regex formats for structured outputs.
 	// Only available for the "sonar" model.
 	ResponseFormat *ResponseFormat `json:"response_format,omitempty" validate:"omitempty"`
+
+	// ImageDomainFilter: Optional. Controls the domain filter for images.
+	// Only available for the "sonar" model.
+	// ImageDomainFilter: Optional. Controls the domain filter for images.
+	// Domain Filtering:
+	//   - prepending the url with - will exclude the domain
+	//   - Use simple domain names like example.com or -gettyimages.com
+	//   - Do not include http://, https://, or subdomains
+	// Filter Strategy:
+	//   - You can mix inclusion and exclusion in domain filters
+	//   - Keep lists short (≤10 entries) for performance and relevance
+	// Performance Notes:
+	//   - Filters may slightly increase response time
+	//   - Overly restrictive filters may reduce result quality or quantity
+	ImageDomainFilter []string `json:"image_domain_filter,omitempty" validate:"omitempty"`
+
+	// ImageFormatFilter: Optional. Controls the format filter for images.
+	// Only available for the "sonar" model.
+	ImageFormatFilter []string `json:"image_format_filter,omitempty" validate:"omitempty"`
 }
 
 // WebSearchOptions specifies web search context size and user location for the request.
@@ -371,6 +368,35 @@ func WithRegexResponseFormat(regex string) CompletionRequestOption {
 	}
 }
 
+// WithImageDomainFilter sets the image domain filter option.
+// Controls which domains to include or exclude for image generation.
+// Domain Filtering:
+//   - prepending the url with - will exclude the domain
+//   - Use simple domain names like example.com or -gettyimages.com
+//   - Do not include http://, https://, or subdomains
+//
+// Filter Strategy:
+//   - You can mix inclusion and exclusion in domain filters
+//   - Keep lists short (≤10 entries) for performance and relevance
+//
+// Performance Notes:
+//   - Filters may slightly increase response time
+//   - Overly restrictive filters may reduce result quality or quantity
+func WithImageDomainFilter(domains []string) CompletionRequestOption {
+	return func(r *CompletionRequest) {
+		r.ImageDomainFilter = domains
+	}
+}
+
+// WithImageFormatFilter sets the image format filter option.
+// Controls which image formats to include in the response.
+// Only available for the "sonar" model.
+func WithImageFormatFilter(formats []string) CompletionRequestOption {
+	return func(r *CompletionRequest) {
+		r.ImageFormatFilter = formats
+	}
+}
+
 // NewCompletionRequest creates a new completion request.
 func NewCompletionRequest(opts ...CompletionRequestOption) *CompletionRequest {
 	r := DefaultCompletionRequest()
@@ -378,108 +404,4 @@ func NewCompletionRequest(opts ...CompletionRequestOption) *CompletionRequest {
 		opt(r)
 	}
 	return r
-}
-
-// Validate validates the completion request.
-func (r *CompletionRequest) Validate() error {
-	validate := validator.New()
-	if err := validate.Struct(r); err != nil {
-		return fmt.Errorf("validation failed: %w", err)
-	}
-	if err := r.ValidateSearchDomainFilter(); err != nil {
-		return err
-	}
-	if err := r.ValidateSearchRecencyFilter(); err != nil {
-		return err
-	}
-	if err := r.ValidateStructuredOutput(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// ValidateSearchDomainFilter validates the search domain filter.
-func (r *CompletionRequest) ValidateSearchDomainFilter() error {
-	if len(r.SearchDomainFilter) > MaxLengthOfSearchDomainFilter {
-		return ErrSearchDomainFilter
-	}
-	return nil
-}
-
-// ValidateSearchRecencyFilter validates the search recency filter.
-func (r *CompletionRequest) ValidateSearchRecencyFilter() error {
-	if r.ReturnImages && r.SearchRecencyFilter != "" {
-		return ErrSearchRecencyFilter
-	}
-	if r.SearchRecencyFilter != "" {
-		switch r.SearchRecencyFilter {
-		case "month", "week", "day", "hour":
-			return nil
-		default:
-			return ErrSearchRecencyFilter
-		}
-	}
-	return nil
-}
-
-// ValidateStructuredOutput validates the structured output configuration.
-func (r *CompletionRequest) ValidateStructuredOutput() error {
-	if r.ResponseFormat == nil {
-		return nil
-	}
-
-	if err := r.validateStructuredOutputModel(); err != nil {
-		return err
-	}
-
-	if err := r.validateStructuredOutputFormat(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// validateStructuredOutputModel validates that the model supports structured output.
-func (r *CompletionRequest) validateStructuredOutputModel() error {
-	if r.Model != "sonar" {
-		return ErrStructuredOutputModelRequirement
-	}
-	return nil
-}
-
-// validateStructuredOutputFormat validates the response format configuration.
-func (r *CompletionRequest) validateStructuredOutputFormat() error {
-	switch r.ResponseFormat.Type {
-	case "json_schema":
-		return r.validateJSONSchemaFormat()
-	case "regex":
-		return r.validateRegexFormat()
-	default:
-		return ErrStructuredOutputFormatMismatch
-	}
-}
-
-// validateJSONSchemaFormat validates JSON Schema format configuration.
-func (r *CompletionRequest) validateJSONSchemaFormat() error {
-	if r.ResponseFormat.JSONSchema == nil {
-		return ErrStructuredOutputFormatMismatch
-	}
-	if r.ResponseFormat.Regex != nil {
-		return ErrStructuredOutputFormatMismatch
-	}
-	return nil
-}
-
-// validateRegexFormat validates Regex format configuration.
-func (r *CompletionRequest) validateRegexFormat() error {
-	if r.ResponseFormat.Regex == nil {
-		return ErrStructuredOutputFormatMismatch
-	}
-	if r.ResponseFormat.JSONSchema != nil {
-		return ErrStructuredOutputFormatMismatch
-	}
-	if r.ReturnImages {
-		return ErrStructuredOutputRegexAndImages
-	}
-	return nil
 }

--- a/perplexity_request_test.go
+++ b/perplexity_request_test.go
@@ -90,45 +90,6 @@ func TestWithSearchRecencyFilter(t *testing.T) {
 	})
 }
 
-func TestSearchRecencyFilterValidationRule(t *testing.T) {
-	validate := validator.New()
-	tests := []struct {
-		name  string
-		value string
-		valid bool
-	}{
-		{"empty value", "", true},
-		{"year is valid", "year", true},
-		{"month is valid", "month", true},
-		{"week is valid", "week", true},
-		{"day is valid", "day", true},
-		{"hour is valid", "hour", true},
-		{"invalid value foo", "foo", false},
-		{"invalid value 2022", "2022", false},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			req := &perplexity.CompletionRequest{
-				Messages:            []perplexity.Message{{Role: "user", Content: "test"}},
-				Model:               perplexity.DefaultModel,
-				MaxTokens:           10,
-				Temperature:         1.0,
-				TopP:                0.5,
-				SearchRecencyFilter: test.value,
-				TopK:                10,
-				PresencePenalty:     0.0,
-				FrequencyPenalty:    1.0,
-			}
-			err := validate.Struct(req)
-			if test.valid {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-			}
-		})
-	}
-}
-
 func TestWebSearchOptionsValidation(t *testing.T) {
 	validate := validator.New()
 	t.Run("valid search_context_size values", func(t *testing.T) {
@@ -242,50 +203,6 @@ func TestWithTopK(t *testing.T) {
 		req := perplexity.NewCompletionRequest(perplexity.WithTopK(topK))
 		assert.Equal(t, req.TopK, topK)
 	})
-}
-
-func TestValidate(t *testing.T) {
-	f := func(testName string, expectedValid bool, opts ...perplexity.CompletionRequestOption) {
-		t.Helper()
-		req := perplexity.NewCompletionRequest(opts...)
-		err := req.Validate()
-		isEqual := assert.Equal(t, expectedValid, err == nil)
-		if !isEqual {
-			t.Logf("Test %s failed", testName)
-		}
-	}
-
-	f("returns error if no message to send to the API", false)
-	f("returns error if model is empty", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(""))
-	f("returns error if MaxTokens is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(-1))
-	f("returns error if Temperature is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTemperature(-1))
-	f("returns error if TopP is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopP(-1))
-	f("returns error if TopK is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopK(-1))
-	f("returns error if TopK is gt 2048", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopK(2049))
-	f("returns error if Temperature is gt 2", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTemperature(2.1))
-	f("returns error if TopP is gt 1", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopP(1.1))
-	f("returns error if SearchDomainFilter contains more than 3 elements", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2", "filter3", "filter4"}))
-	f("returns error return_images and searchRecencyFilter are set", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(10), perplexity.WithTemperature(0.5), perplexity.WithTopP(0.5), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2"}), perplexity.WithReturnImages(true), perplexity.WithReturnRelatedQuestions(true), perplexity.WithSearchRecencyFilter("filter"), perplexity.WithTopK(10))
-	f("returns no error", true, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(10), perplexity.WithTemperature(0.5), perplexity.WithTopP(0.5), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2"}), perplexity.WithReturnRelatedQuestions(true), perplexity.WithTopK(10))
-}
-
-func TestValidateSearchRecencyFilter(t *testing.T) {
-	f := func(testName string, expectedValid bool, opts ...perplexity.CompletionRequestOption) {
-		t.Helper()
-		req := perplexity.NewCompletionRequest(opts...)
-		err := req.ValidateSearchRecencyFilter()
-		isEqual := assert.Equal(t, expectedValid, err == nil)
-		if !isEqual {
-			t.Logf("Test %s failed", testName)
-		}
-	}
-
-	f("returns no error if SearchRecencyFilter is empty", true)
-	f("returns no error if SearchRecencyFilter is set to 'hour'", true, perplexity.WithSearchRecencyFilter("hour"))
-	f("returns no error if SearchRecencyFilter is set to 'day'", true, perplexity.WithSearchRecencyFilter("day"))
-	f("returns no error if SearchRecencyFilter is set to 'week'", true, perplexity.WithSearchRecencyFilter("week"))
-	f("returns no error if SearchRecencyFilter is set to 'month'", true, perplexity.WithSearchRecencyFilter("month"))
-	f("returns error if SearchRecencyFilter is set to 'year'", false, perplexity.WithSearchRecencyFilter("year"))
 }
 
 func TestWithPresencePenalty(t *testing.T) {
@@ -454,152 +371,6 @@ func TestWithRegexResponseFormat(t *testing.T) {
 	})
 }
 
-func TestStructuredOutputValidation(t *testing.T) {
-	t.Run("validates JSON schema structured output with sonar model", func(t *testing.T) {
-		msg := []perplexity.Message{
-			{
-				Role:    "user",
-				Content: "hello",
-			},
-		}
-		schema := map[string]interface{}{
-			"type": "object",
-			"properties": map[string]interface{}{
-				"message": map[string]interface{}{
-					"type": "string",
-				},
-			},
-		}
-		req := perplexity.NewCompletionRequest(
-			perplexity.WithMessages(msg),
-			perplexity.WithModel("sonar"),
-			perplexity.WithJSONSchemaResponseFormat(schema),
-		)
-		err := req.Validate()
-		assert.NoError(t, err)
-	})
-
-	t.Run("validates regex structured output with sonar model", func(t *testing.T) {
-		msg := []perplexity.Message{
-			{
-				Role:    "user",
-				Content: "hello",
-			},
-		}
-		regex := `\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`
-		req := perplexity.NewCompletionRequest(
-			perplexity.WithMessages(msg),
-			perplexity.WithModel("sonar"),
-			perplexity.WithRegexResponseFormat(regex),
-		)
-		err := req.Validate()
-		assert.NoError(t, err)
-	})
-
-	t.Run("rejects structured output with non-sonar model", func(t *testing.T) {
-		msg := []perplexity.Message{
-			{
-				Role:    "user",
-				Content: "hello",
-			},
-		}
-		schema := map[string]interface{}{
-			"type": "object",
-		}
-		req := perplexity.NewCompletionRequest(
-			perplexity.WithMessages(msg),
-			perplexity.WithModel("llama-3.1-sonar-small-128k-online"),
-			perplexity.WithJSONSchemaResponseFormat(schema),
-		)
-		err := req.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "structured output (response_format) is only available for the 'sonar' model")
-	})
-
-	t.Run("rejects invalid json_schema configuration", func(t *testing.T) {
-		msg := []perplexity.Message{
-			{
-				Role:    "user",
-				Content: "hello",
-			},
-		}
-		responseFormat := &perplexity.ResponseFormat{
-			Type: "json_schema",
-			// Missing JSONSchema config
-		}
-		req := perplexity.NewCompletionRequest(
-			perplexity.WithMessages(msg),
-			perplexity.WithModel("sonar"),
-			perplexity.WithResponseFormat(responseFormat),
-		)
-		err := req.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "response format type must match the provided configuration")
-	})
-
-	t.Run("rejects invalid regex configuration", func(t *testing.T) {
-		msg := []perplexity.Message{
-			{
-				Role:    "user",
-				Content: "hello",
-			},
-		}
-		responseFormat := &perplexity.ResponseFormat{
-			Type: "regex",
-			// Missing Regex config
-		}
-		req := perplexity.NewCompletionRequest(
-			perplexity.WithMessages(msg),
-			perplexity.WithModel("sonar"),
-			perplexity.WithResponseFormat(responseFormat),
-		)
-		err := req.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "response format type must match the provided configuration")
-	})
-
-	t.Run("rejects mixed configuration", func(t *testing.T) {
-		msg := []perplexity.Message{
-			{
-				Role:    "user",
-				Content: "hello",
-			},
-		}
-		responseFormat := &perplexity.ResponseFormat{
-			Type: "json_schema",
-			JSONSchema: &perplexity.JSONSchemaConfig{
-				Schema: map[string]interface{}{"type": "object"},
-			},
-			Regex: &perplexity.RegexConfig{
-				Regex: `\d+`,
-			},
-		}
-		req := perplexity.NewCompletionRequest(
-			perplexity.WithMessages(msg),
-			perplexity.WithModel("sonar"),
-			perplexity.WithResponseFormat(responseFormat),
-		)
-		err := req.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "response format type must match the provided configuration")
-	})
-
-	t.Run("allows request without structured output", func(t *testing.T) {
-		msg := []perplexity.Message{
-			{
-				Role:    "user",
-				Content: "hello",
-			},
-		}
-		req := perplexity.NewCompletionRequest(
-			perplexity.WithMessages(msg),
-			perplexity.WithModel("llama-3.1-sonar-small-128k-online"),
-		)
-		err := req.Validate()
-		assert.NoError(t, err)
-	})
-}
-
 func TestStructuredOutputJSONSerialization(t *testing.T) {
 	t.Run("serializes JSON schema response format correctly", func(t *testing.T) {
 		schema := map[string]interface{}{
@@ -616,18 +387,18 @@ func TestStructuredOutputJSONSerialization(t *testing.T) {
 				Schema: schema,
 			},
 		}
-		
+
 		data, err := json.Marshal(responseFormat)
 		assert.NoError(t, err)
-		
+
 		var result map[string]interface{}
 		err = json.Unmarshal(data, &result)
 		assert.NoError(t, err)
-		
+
 		assert.Equal(t, "json_schema", result["type"])
 		assert.NotNil(t, result["json_schema"])
 		assert.Nil(t, result["regex"])
-		
+
 		jsonSchema := result["json_schema"].(map[string]interface{})
 		assert.Equal(t, schema, jsonSchema["schema"])
 	})
@@ -640,18 +411,18 @@ func TestStructuredOutputJSONSerialization(t *testing.T) {
 				Regex: regex,
 			},
 		}
-		
+
 		data, err := json.Marshal(responseFormat)
 		assert.NoError(t, err)
-		
+
 		var result map[string]interface{}
 		err = json.Unmarshal(data, &result)
 		assert.NoError(t, err)
-		
+
 		assert.Equal(t, "regex", result["type"])
 		assert.NotNil(t, result["regex"])
 		assert.Nil(t, result["json_schema"])
-		
+
 		regexConfig := result["regex"].(map[string]interface{})
 		assert.Equal(t, regex, regexConfig["regex"])
 	})

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -9,6 +9,11 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+const (
+	// MaxLengthOfDomainFilter is the maximum number of domains allowed in the search domain filter.
+	MaxLengthOfDomainFilter = 10
+)
+
 // Error definitions for CompletionRequest validation.
 var (
 	// ErrSearchDomainFilter is returned when the search domain filter exceeds the maximum allowed number of domains.
@@ -113,10 +118,7 @@ func (v *RequestValidator) ValidateRequest(req *CompletionRequest) error {
 
 // validateSearchDomainFilter validates the search domain filter.
 func (v *RequestValidator) validateSearchDomainFilter(req *CompletionRequest) error {
-	if len(req.SearchDomainFilter) > MaxLengthOfSearchDomainFilter {
-		return ErrSearchDomainFilter
-	}
-	return nil
+	return validateDomainList(req.SearchDomainFilter)
 }
 
 // validateSearchRecencyFilter validates the search recency filter.
@@ -199,24 +201,7 @@ func (v *RequestValidator) validateRegexFormat(req *CompletionRequest) error {
 
 // validateImageDomainFilter validates the image domain filter.
 func (v *RequestValidator) validateImageDomainFilter(req *CompletionRequest) error {
-	if len(req.ImageDomainFilter) == 0 {
-		return nil
-	}
-
-	// Check list length (≤10 entries)
-	maxNumberOfDomains := 10
-	if len(req.ImageDomainFilter) > maxNumberOfDomains {
-		return ErrImageDomainFilterTooLong
-	}
-
-	// Validate each domain
-	for _, domain := range req.ImageDomainFilter {
-		if err := validateImageDomain(domain); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return validateDomainList(req.ImageDomainFilter)
 }
 
 // validateImageFormatFilter validates the image format filter.
@@ -235,8 +220,27 @@ func (v *RequestValidator) validateImageFormatFilter(req *CompletionRequest) err
 	return nil
 }
 
-// validateImageDomain validates a single image domain filter entry.
-func validateImageDomain(domain string) error {
+func validateDomainList(domainList []string) error {
+	if len(domainList) == 0 {
+		return nil
+	}
+
+	if len(domainList) > MaxLengthOfDomainFilter {
+		return ErrImageDomainFilterTooLong
+	}
+
+	// Validate each domain
+	for _, domain := range domainList {
+		if err := validateDomain(domain); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateDomain validates a single image domain filter entry.
+func validateDomain(domain string) error {
 	if domain == "" {
 		return ErrImageDomainFilterEmpty
 	}

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -1,0 +1,320 @@
+package perplexity
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// Error definitions for CompletionRequest validation
+var (
+	// ErrSearchDomainFilter is returned when the search domain filter exceeds the maximum allowed number of domains.
+	ErrSearchDomainFilter = errors.New("search domain filter must be less than or equal to 3")
+
+	// ErrSearchRecencyFilter is returned when the search recency filter is invalid or incompatible.
+	ErrSearchRecencyFilter = errors.New("search recency filter must be one of month, week, day, hour and is incompatible with images")
+
+	// ErrRegexAndImages is returned when both regex response format and images are requested, which are incompatible.
+	ErrRegexAndImages = errors.New("regex and images are not compatible")
+
+	// ErrRegexAndStream is returned when both regex response format and streaming are requested, which are incompatible.
+	ErrRegexAndStream = errors.New("regex and stream are not compatible")
+
+	// ErrValidationFailed is returned when struct validation fails.
+	ErrValidationFailed = errors.New("validation failed")
+
+	// ErrStructuredOutputModelRequirement is returned when structured output is used with an unsupported model.
+	ErrStructuredOutputModelRequirement = errors.New("structured output (response_format) is only available for the 'sonar' model")
+
+	// ErrStructuredOutputFormatMismatch is returned when the response format configuration doesn't match the type.
+	ErrStructuredOutputFormatMismatch = errors.New("response format type must match the provided configuration (json_schema or regex)")
+
+	// ErrStructuredOutputRegexAndImages is returned when regex and images are used together.
+	ErrStructuredOutputRegexAndImages = errors.New("regex and images are not compatible")
+
+	// ErrImageDomainFilterTooLong is returned when the image domain filter exceeds the maximum allowed number of domains.
+	ErrImageDomainFilterTooLong = errors.New("image domain filter must be less than or equal to 10")
+
+	// ErrImageDomainFilterEmpty is returned when an image domain filter entry is empty.
+	ErrImageDomainFilterEmpty = errors.New("image domain filter entry cannot be empty")
+
+	// ErrImageDomainFilterProtocolNotAllowed is returned when an image domain filter entry includes a protocol prefix (http:// or https://).
+	ErrImageDomainFilterProtocolNotAllowed = errors.New("image domain filter entry cannot include http:// or https://")
+
+	// ErrImageDomainFilterSubdomainNotAllowed is returned when an image domain filter entry includes subdomains.
+	ErrImageDomainFilterSubdomainNotAllowed = errors.New("image domain filter entry cannot include subdomains")
+
+	// ErrImageDomainFilterInvalidFormat is returned when an image domain filter entry has an invalid format.
+	ErrImageDomainFilterInvalidFormat = errors.New("image domain filter entry must be a valid domain name (e.g., example.com or -gettyimages.com)")
+
+	// ErrImageFormatFilterTooLong is returned when the image format filter exceeds the maximum allowed number of formats.
+	ErrImageFormatFilterTooLong = errors.New("image format filter must be less than or equal to 10")
+
+	// ErrImageFormatFilterEmpty is returned when an image format filter entry is empty.
+	ErrImageFormatFilterEmpty = errors.New("image format filter entry cannot be empty")
+
+	// ErrImageFormatFilterDotPrefixNotAllowed is returned when an image format filter entry starts with a dot.
+	ErrImageFormatFilterDotPrefixNotAllowed = errors.New("image format filter entry cannot start with a dot (e.g., .gif)")
+
+	// ErrImageFormatFilterMustBeLowercase is returned when an image format filter entry is not in lowercase.
+	ErrImageFormatFilterMustBeLowercase = errors.New("image format filter entry must be in lowercase")
+
+	// ErrImageFormatFilterInvalidFormat is returned when an image format filter entry has an invalid format.
+	ErrImageFormatFilterInvalidFormat = errors.New("image format filter entry must be a valid format (e.g., jpg, png, webp)")
+)
+
+// RequestValidator provides validation functionality for CompletionRequest.
+// This is a stateless validator that can be reused across multiple requests.
+type RequestValidator struct {
+	validator *validator.Validate
+}
+
+// NewRequestValidator creates a new RequestValidator instance.
+func NewRequestValidator() *RequestValidator {
+	return &RequestValidator{
+		validator: validator.New(),
+	}
+}
+
+// DefaultValidator is a package-level validator instance for convenience.
+var DefaultValidator = NewRequestValidator()
+
+// Validate validates the completion request using the default validator.
+func (r *CompletionRequest) Validate() error {
+	return DefaultValidator.ValidateRequest(r)
+}
+
+// ValidateRequest validates a CompletionRequest using the validator instance.
+func (v *RequestValidator) ValidateRequest(req *CompletionRequest) error {
+	if req == nil {
+		return fmt.Errorf("%w: request cannot be nil", ErrValidationFailed)
+	}
+
+	// Validate struct tags first
+	if err := v.validator.Struct(req); err != nil {
+		return fmt.Errorf("%w: %w", ErrValidationFailed, err)
+	}
+
+	// Run custom validations
+	validators := []func(*CompletionRequest) error{
+		v.validateSearchDomainFilter,
+		v.validateSearchRecencyFilter,
+		v.validateStructuredOutput,
+		v.validateImageDomainFilter,
+		v.validateImageFormatFilter,
+	}
+
+	for _, validator := range validators {
+		if err := validator(req); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateSearchDomainFilter validates the search domain filter.
+func (v *RequestValidator) validateSearchDomainFilter(req *CompletionRequest) error {
+	if len(req.SearchDomainFilter) > MaxLengthOfSearchDomainFilter {
+		return ErrSearchDomainFilter
+	}
+	return nil
+}
+
+// validateSearchRecencyFilter validates the search recency filter.
+func (v *RequestValidator) validateSearchRecencyFilter(req *CompletionRequest) error {
+	if req.ReturnImages && req.SearchRecencyFilter != "" {
+		return ErrSearchRecencyFilter
+	}
+	if req.SearchRecencyFilter != "" {
+		switch req.SearchRecencyFilter {
+		case "month", "week", "day", "hour":
+			return nil
+		default:
+			return ErrSearchRecencyFilter
+		}
+	}
+	return nil
+}
+
+// validateStructuredOutput validates the structured output configuration.
+func (v *RequestValidator) validateStructuredOutput(req *CompletionRequest) error {
+	if req.ResponseFormat == nil {
+		return nil
+	}
+
+	if err := v.validateStructuredOutputModel(req); err != nil {
+		return err
+	}
+
+	if err := v.validateStructuredOutputFormat(req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateStructuredOutputModel validates that the model supports structured output.
+func (v *RequestValidator) validateStructuredOutputModel(req *CompletionRequest) error {
+	if req.Model != "sonar" {
+		return ErrStructuredOutputModelRequirement
+	}
+	return nil
+}
+
+// validateStructuredOutputFormat validates the response format configuration.
+func (v *RequestValidator) validateStructuredOutputFormat(req *CompletionRequest) error {
+	switch req.ResponseFormat.Type {
+	case "json_schema":
+		return v.validateJSONSchemaFormat(req)
+	case "regex":
+		return v.validateRegexFormat(req)
+	default:
+		return ErrStructuredOutputFormatMismatch
+	}
+}
+
+// validateJSONSchemaFormat validates JSON Schema format configuration.
+func (v *RequestValidator) validateJSONSchemaFormat(req *CompletionRequest) error {
+	if req.ResponseFormat.JSONSchema == nil {
+		return ErrStructuredOutputFormatMismatch
+	}
+	if req.ResponseFormat.Regex != nil {
+		return ErrStructuredOutputFormatMismatch
+	}
+	return nil
+}
+
+// validateRegexFormat validates Regex format configuration.
+func (v *RequestValidator) validateRegexFormat(req *CompletionRequest) error {
+	if req.ResponseFormat.Regex == nil {
+		return ErrStructuredOutputFormatMismatch
+	}
+	if req.ResponseFormat.JSONSchema != nil {
+		return ErrStructuredOutputFormatMismatch
+	}
+	if req.ReturnImages {
+		return ErrStructuredOutputRegexAndImages
+	}
+	return nil
+}
+
+// validateImageDomainFilter validates the image domain filter.
+func (v *RequestValidator) validateImageDomainFilter(req *CompletionRequest) error {
+	if len(req.ImageDomainFilter) == 0 {
+		return nil
+	}
+
+	// Check list length (≤10 entries)
+	if len(req.ImageDomainFilter) > 10 {
+		return ErrImageDomainFilterTooLong
+	}
+
+	// Validate each domain
+	for _, domain := range req.ImageDomainFilter {
+		if err := validateImageDomain(domain); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateImageFormatFilter validates the image format filter.
+func (v *RequestValidator) validateImageFormatFilter(req *CompletionRequest) error {
+	if len(req.ImageFormatFilter) == 0 {
+		return nil
+	}
+
+	// Validate each format
+	for _, format := range req.ImageFormatFilter {
+		if err := validateImageFormat(format); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateImageDomain validates a single image domain filter entry.
+func validateImageDomain(domain string) error {
+	if domain == "" {
+		return ErrImageDomainFilterEmpty
+	}
+
+	// Check for protocol prefixes (should not include http://, https://)
+	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
+		return ErrImageDomainFilterProtocolNotAllowed
+	}
+
+	// Check for subdomains (should not include subdomains)
+	if strings.Count(domain, ".") > 1 {
+		return ErrImageDomainFilterSubdomainNotAllowed
+	}
+
+	// Check for valid domain format (simple domain names)
+	// Allow exclusion prefix (-) but validate the rest
+	cleanDomain := domain
+	if strings.HasPrefix(domain, "-") {
+		cleanDomain = domain[1:]
+	}
+
+	// Basic domain validation (alphanumeric, hyphens, dots)
+	matched, err := regexp.MatchString(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$`, cleanDomain)
+	if err != nil || !matched {
+		return ErrImageDomainFilterInvalidFormat
+	}
+
+	return nil
+}
+
+// validateImageFormat validates a single image format filter entry.
+func validateImageFormat(format string) error {
+	if format == "" {
+		return ErrImageFormatFilterEmpty
+	}
+
+	// Check for dot prefix (should not include ie. gif not .gif)
+	if strings.HasPrefix(format, ".") {
+		return ErrImageFormatFilterDotPrefixNotAllowed
+	}
+
+	// Check for uppercase (must be lowercase)
+	if format != strings.ToLower(format) {
+		return ErrImageFormatFilterMustBeLowercase
+	}
+
+	// Check for valid format (alphanumeric only)
+	matched, err := regexp.MatchString(`^[a-z0-9]+$`, format)
+	if err != nil || !matched {
+		return ErrImageFormatFilterInvalidFormat
+	}
+
+	return nil
+}
+
+// Package-level convenience functions for backward compatibility
+
+// ValidateSearchDomainFilter validates the search domain filter.
+//
+//go:deprecated
+func (r *CompletionRequest) ValidateSearchDomainFilter() error {
+	return DefaultValidator.validateSearchDomainFilter(r)
+}
+
+// ValidateSearchRecencyFilter validates the search recency filter.
+//
+//go:deprecated
+func (r *CompletionRequest) ValidateSearchRecencyFilter() error {
+	return DefaultValidator.validateSearchRecencyFilter(r)
+}
+
+// ValidateStructuredOutput validates the structured output configuration.
+//
+//go:deprecated
+func (r *CompletionRequest) ValidateStructuredOutput() error {
+	return DefaultValidator.validateStructuredOutput(r)
+}

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -79,14 +79,6 @@ func NewRequestValidator() *RequestValidator {
 	}
 }
 
-// DefaultValidator is a package-level validator instance for convenience.
-var DefaultValidator = NewRequestValidator()
-
-// Validate validates the completion request using the default validator.
-func (r *CompletionRequest) Validate() error {
-	return DefaultValidator.ValidateRequest(r)
-}
-
 // ValidateRequest validates a CompletionRequest using the validator instance.
 func (v *RequestValidator) ValidateRequest(req *CompletionRequest) error {
 	if req == nil {
@@ -297,25 +289,32 @@ func validateImageFormat(format string) error {
 	return nil
 }
 
-// Package-level convenience functions for backward compatibility
+// CompletionRequest validators for backward compatibility
+
+// Validate validates the completion request using the default validator.
+//
+//go:deprecated
+func (r *CompletionRequest) Validate() error {
+	return NewRequestValidator().ValidateRequest(r)
+}
 
 // ValidateSearchDomainFilter validates the search domain filter.
 //
 //go:deprecated
 func (r *CompletionRequest) ValidateSearchDomainFilter() error {
-	return DefaultValidator.validateSearchDomainFilter(r)
+	return NewRequestValidator().validateSearchDomainFilter(r)
 }
 
 // ValidateSearchRecencyFilter validates the search recency filter.
 //
 //go:deprecated
 func (r *CompletionRequest) ValidateSearchRecencyFilter() error {
-	return DefaultValidator.validateSearchRecencyFilter(r)
+	return NewRequestValidator().validateSearchRecencyFilter(r)
 }
 
 // ValidateStructuredOutput validates the structured output configuration.
 //
 //go:deprecated
 func (r *CompletionRequest) ValidateStructuredOutput() error {
-	return DefaultValidator.validateStructuredOutput(r)
+	return NewRequestValidator().validateStructuredOutput(r)
 }

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -16,9 +16,6 @@ const (
 
 // Error definitions for CompletionRequest validation.
 var (
-	// ErrSearchDomainFilter is returned when the search domain filter exceeds the maximum allowed number of domains.
-	ErrSearchDomainFilter = errors.New("search domain filter must be less than or equal to 3")
-
 	// ErrSearchRecencyFilter is returned when the search recency filter is invalid or incompatible.
 	ErrSearchRecencyFilter = errors.New("search recency filter must be one of month, week, day, hour and is incompatible with images")
 
@@ -40,23 +37,23 @@ var (
 	// ErrStructuredOutputRegexAndImages is returned when regex and images are used together.
 	ErrStructuredOutputRegexAndImages = errors.New("regex and images are not compatible")
 
-	// ErrImageDomainFilterTooLong is returned when the image domain filter exceeds the maximum allowed number of domains.
-	ErrImageDomainFilterTooLong = errors.New("image domain filter must be less than or equal to 10")
+	// ErrDomainFilterTooLong is returned when the domain filter exceeds the maximum allowed number of domains.
+	ErrDomainFilterTooLong = errors.New("domain filter must be less than or equal to 10")
 
-	// ErrImageDomainFilterEmpty is returned when an image domain filter entry is empty.
-	ErrImageDomainFilterEmpty = errors.New("image domain filter entry cannot be empty")
+	// ErrDomainFilterEmpty is returned when a domain filter entry is empty.
+	ErrDomainFilterEmpty = errors.New("domain filter entry cannot be empty")
 
-	// ErrImageDomainFilterProtocolNotAllowed is returned when an image domain filter entry includes a protocol prefix (http:// or https://).
-	ErrImageDomainFilterProtocolNotAllowed = errors.New("image domain filter entry cannot include http:// or https://")
+	// ErrDomainFilterProtocolNotAllowed is returned when a domain filter entry includes a protocol prefix (http:// or https://).
+	ErrDomainFilterProtocolNotAllowed = errors.New("domain filter entry cannot include http:// or https://")
 
-	// ErrImageDomainFilterWWWNotAllowed is returned when an image domain filter entry includes a www. prefix.
-	ErrImageDomainFilterWWWNotAllowed = errors.New("image domain filter entry cannot include www. prefix")
+	// ErrDomainFilterWWWNotAllowed is returned when a domain filter entry includes a www. prefix.
+	ErrDomainFilterWWWNotAllowed = errors.New("domain filter entry cannot include www. prefix")
 
-	// ErrImageDomainFilterSubdomainNotAllowed is returned when an image domain filter entry includes subdomains.
-	ErrImageDomainFilterSubdomainNotAllowed = errors.New("image domain filter entry cannot include subdomains")
+	// ErrDomainFilterSubdomainNotAllowed is returned when a domain filter entry includes subdomains.
+	ErrDomainFilterSubdomainNotAllowed = errors.New("domain filter entry cannot include subdomains")
 
-	// ErrImageDomainFilterInvalidFormat is returned when an image domain filter entry has an invalid format.
-	ErrImageDomainFilterInvalidFormat = errors.New("image domain filter entry must be a valid domain name (e.g., example.com or -gettyimages.com)")
+	// ErrDomainFilterInvalidFormat is returned when a domain filter entry has an invalid format.
+	ErrDomainFilterInvalidFormat = errors.New("domain filter entry must be a valid domain name (e.g., example.com or -gettyimages.com)")
 
 	// ErrImageFormatFilterTooLong is returned when the image format filter exceeds the maximum allowed number of formats.
 	ErrImageFormatFilterTooLong = errors.New("image format filter must be less than or equal to 10")
@@ -226,7 +223,7 @@ func validateDomainList(domainList []string) error {
 	}
 
 	if len(domainList) > MaxLengthOfDomainFilter {
-		return ErrImageDomainFilterTooLong
+		return ErrDomainFilterTooLong
 	}
 
 	// Validate each domain
@@ -239,10 +236,10 @@ func validateDomainList(domainList []string) error {
 	return nil
 }
 
-// validateDomain validates a single image domain filter entry.
+// validateDomain validates a single domain filter entry.
 func validateDomain(domain string) error {
 	if domain == "" {
-		return ErrImageDomainFilterEmpty
+		return ErrDomainFilterEmpty
 	}
 
 	// Check for valid domain format (simple domain names)
@@ -251,22 +248,22 @@ func validateDomain(domain string) error {
 
 	// Check for protocol prefixes (should not include http://, https://)
 	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
-		return ErrImageDomainFilterProtocolNotAllowed
+		return ErrDomainFilterProtocolNotAllowed
 	}
 
 	if strings.HasPrefix(domain, "www.") {
-		return ErrImageDomainFilterWWWNotAllowed
+		return ErrDomainFilterWWWNotAllowed
 	}
 
 	// Check for subdomains (should not include subdomains)
 	if strings.Count(domain, ".") > 1 {
-		return ErrImageDomainFilterSubdomainNotAllowed
+		return ErrDomainFilterSubdomainNotAllowed
 	}
 
 	// Basic domain validation (alphanumeric, hyphens, dots)
 	matched, err := regexp.MatchString(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$`, domain)
 	if err != nil || !matched {
-		return ErrImageDomainFilterInvalidFormat
+		return ErrDomainFilterInvalidFormat
 	}
 
 	return nil

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -44,6 +44,9 @@ var (
 	// ErrImageDomainFilterProtocolNotAllowed is returned when an image domain filter entry includes a protocol prefix (http:// or https://).
 	ErrImageDomainFilterProtocolNotAllowed = errors.New("image domain filter entry cannot include http:// or https://")
 
+	// ErrImageDomainFilterWWWNotAllowed is returned when an image domain filter entry includes a www. prefix.
+	ErrImageDomainFilterWWWNotAllowed = errors.New("image domain filter entry cannot include www. prefix")
+
 	// ErrImageDomainFilterSubdomainNotAllowed is returned when an image domain filter entry includes subdomains.
 	ErrImageDomainFilterSubdomainNotAllowed = errors.New("image domain filter entry cannot include subdomains")
 
@@ -238,9 +241,19 @@ func validateImageDomain(domain string) error {
 		return ErrImageDomainFilterEmpty
 	}
 
+	// Check for valid domain format (simple domain names)
+	// Allow exclusion prefix (-) but validate the rest
+	if strings.HasPrefix(domain, "-") {
+		domain = domain[1:]
+	}
+
 	// Check for protocol prefixes (should not include http://, https://)
 	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
 		return ErrImageDomainFilterProtocolNotAllowed
+	}
+
+	if strings.HasPrefix(domain, "www.") {
+		return ErrImageDomainFilterWWWNotAllowed
 	}
 
 	// Check for subdomains (should not include subdomains)
@@ -248,15 +261,8 @@ func validateImageDomain(domain string) error {
 		return ErrImageDomainFilterSubdomainNotAllowed
 	}
 
-	// Check for valid domain format (simple domain names)
-	// Allow exclusion prefix (-) but validate the rest
-	cleanDomain := domain
-	if strings.HasPrefix(domain, "-") {
-		cleanDomain = domain[1:]
-	}
-
 	// Basic domain validation (alphanumeric, hyphens, dots)
-	matched, err := regexp.MatchString(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$`, cleanDomain)
+	matched, err := regexp.MatchString(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$`, domain)
 	if err != nil || !matched {
 		return ErrImageDomainFilterInvalidFormat
 	}

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -243,9 +243,7 @@ func validateImageDomain(domain string) error {
 
 	// Check for valid domain format (simple domain names)
 	// Allow exclusion prefix (-) but validate the rest
-	if strings.HasPrefix(domain, "-") {
-		domain = domain[1:]
-	}
+	domain = strings.TrimPrefix(domain, "-")
 
 	// Check for protocol prefixes (should not include http://, https://)
 	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-// Error definitions for CompletionRequest validation
+// Error definitions for CompletionRequest validation.
 var (
 	// ErrSearchDomainFilter is returned when the search domain filter exceeds the maximum allowed number of domains.
 	ErrSearchDomainFilter = errors.New("search domain filter must be less than or equal to 3")
@@ -209,7 +209,8 @@ func (v *RequestValidator) validateImageDomainFilter(req *CompletionRequest) err
 	}
 
 	// Check list length (≤10 entries)
-	if len(req.ImageDomainFilter) > 10 {
+	maxNumberOfDomains := 10
+	if len(req.ImageDomainFilter) > maxNumberOfDomains {
 		return ErrImageDomainFilterTooLong
 	}
 

--- a/perplexity_request_validator_test.go
+++ b/perplexity_request_validator_test.go
@@ -1,0 +1,633 @@
+package perplexity_test
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/sgaunet/perplexity-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	validator := perplexity.NewRequestValidator()
+
+	f := func(testName string, expectedValid bool, opts ...perplexity.CompletionRequestOption) {
+		t.Helper()
+		req := perplexity.NewCompletionRequest(opts...)
+		err := validator.ValidateRequest(req)
+		isEqual := assert.Equal(t, expectedValid, err == nil)
+		if !isEqual {
+			t.Logf("Test %s failed", testName)
+		}
+	}
+
+	f("returns error if no message to send to the API", false)
+	f("returns error if model is empty", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(""))
+	f("returns error if MaxTokens is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(-1))
+	f("returns error if Temperature is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTemperature(-1))
+	f("returns error if TopP is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopP(-1))
+	f("returns error if TopK is negative", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopK(-1))
+	f("returns error if TopK is gt 2048", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopK(2049))
+	f("returns error if Temperature is gt 2", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTemperature(2.1))
+	f("returns error if TopP is gt 1", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopP(1.1))
+	f("returns error if SearchDomainFilter contains more than 3 elements", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2", "filter3", "filter4"}))
+	f("returns error return_images and searchRecencyFilter are set", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(10), perplexity.WithTemperature(0.5), perplexity.WithTopP(0.5), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2"}), perplexity.WithReturnImages(true), perplexity.WithReturnRelatedQuestions(true), perplexity.WithSearchRecencyFilter("filter"), perplexity.WithTopK(10))
+	f("returns no error", true, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(10), perplexity.WithTemperature(0.5), perplexity.WithTopP(0.5), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2"}), perplexity.WithReturnRelatedQuestions(true), perplexity.WithTopK(10))
+}
+
+func TestValidateSearchRecencyFilter(t *testing.T) {
+	f := func(testName string, expectedValid bool, opts ...perplexity.CompletionRequestOption) {
+		t.Helper()
+		req := perplexity.NewCompletionRequest(opts...)
+		err := req.ValidateSearchRecencyFilter()
+		isEqual := assert.Equal(t, expectedValid, err == nil)
+		if !isEqual {
+			t.Logf("Test %s failed", testName)
+		}
+	}
+
+	f("returns no error if SearchRecencyFilter is empty", true)
+	f("returns no error if SearchRecencyFilter is set to 'hour'", true, perplexity.WithSearchRecencyFilter("hour"))
+	f("returns no error if SearchRecencyFilter is set to 'day'", true, perplexity.WithSearchRecencyFilter("day"))
+	f("returns no error if SearchRecencyFilter is set to 'week'", true, perplexity.WithSearchRecencyFilter("week"))
+	f("returns no error if SearchRecencyFilter is set to 'month'", true, perplexity.WithSearchRecencyFilter("month"))
+	f("returns error if SearchRecencyFilter is set to 'year'", false, perplexity.WithSearchRecencyFilter("year"))
+}
+
+func TestStructuredOutputValidation(t *testing.T) {
+	validator := perplexity.NewRequestValidator()
+
+	t.Run("validates JSON schema structured output with sonar model", func(t *testing.T) {
+		msg := []perplexity.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		}
+		schema := map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"message": map[string]interface{}{
+					"type": "string",
+				},
+			},
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages(msg),
+			perplexity.WithModel("sonar"),
+			perplexity.WithJSONSchemaResponseFormat(schema),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("validates regex structured output with sonar model", func(t *testing.T) {
+		msg := []perplexity.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		}
+		regex := `\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages(msg),
+			perplexity.WithModel("sonar"),
+			perplexity.WithRegexResponseFormat(regex),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects structured output with non-sonar model", func(t *testing.T) {
+		msg := []perplexity.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		}
+		schema := map[string]interface{}{
+			"type": "object",
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages(msg),
+			perplexity.WithModel("llama-3.1-sonar-small-128k-online"),
+			perplexity.WithJSONSchemaResponseFormat(schema),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "structured output (response_format) is only available for the 'sonar' model")
+	})
+
+	t.Run("rejects invalid json_schema configuration", func(t *testing.T) {
+		msg := []perplexity.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		}
+		responseFormat := &perplexity.ResponseFormat{
+			Type: "json_schema",
+			// Missing JSONSchema config
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages(msg),
+			perplexity.WithModel("sonar"),
+			perplexity.WithResponseFormat(responseFormat),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "response format type must match the provided configuration")
+	})
+
+	t.Run("rejects invalid regex configuration", func(t *testing.T) {
+		msg := []perplexity.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		}
+		responseFormat := &perplexity.ResponseFormat{
+			Type: "regex",
+			// Missing Regex config
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages(msg),
+			perplexity.WithModel("sonar"),
+			perplexity.WithResponseFormat(responseFormat),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "response format type must match the provided configuration")
+	})
+
+	t.Run("rejects mixed configuration", func(t *testing.T) {
+		msg := []perplexity.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		}
+		responseFormat := &perplexity.ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &perplexity.JSONSchemaConfig{
+				Schema: map[string]interface{}{"type": "object"},
+			},
+			Regex: &perplexity.RegexConfig{
+				Regex: `\d+`,
+			},
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages(msg),
+			perplexity.WithModel("sonar"),
+			perplexity.WithResponseFormat(responseFormat),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "response format type must match the provided configuration")
+	})
+
+	t.Run("allows request without structured output", func(t *testing.T) {
+		msg := []perplexity.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages(msg),
+			perplexity.WithModel("llama-3.1-sonar-small-128k-online"),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+}
+
+func TestSearchRecencyFilterValidationRule(t *testing.T) {
+	validate := validator.New()
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{"empty value", "", true},
+		{"year is valid", "year", true},
+		{"month is valid", "month", true},
+		{"week is valid", "week", true},
+		{"day is valid", "day", true},
+		{"hour is valid", "hour", true},
+		{"invalid value foo", "foo", false},
+		{"invalid value 2022", "2022", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &perplexity.CompletionRequest{
+				Messages:            []perplexity.Message{{Role: "user", Content: "test"}},
+				Model:               perplexity.DefaultModel,
+				MaxTokens:           10,
+				Temperature:         1.0,
+				TopP:                0.5,
+				SearchRecencyFilter: test.value,
+				TopK:                10,
+				PresencePenalty:     0.0,
+				FrequencyPenalty:    1.0,
+			}
+			err := validate.Struct(req)
+			if test.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSearchDomainFilter(t *testing.T) {
+	t.Run("returns no error for empty filter", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+		)
+		err := req.ValidateSearchDomainFilter()
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for valid filter length", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithSearchDomainFilter([]string{"example.com", "test.com"}),
+		)
+		err := req.ValidateSearchDomainFilter()
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for maximum allowed length", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithSearchDomainFilter([]string{"domain1.com", "domain2.com", "domain3.com"}),
+		)
+		err := req.ValidateSearchDomainFilter()
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error for exceeding maximum length", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithSearchDomainFilter([]string{"domain1.com", "domain2.com", "domain3.com", "domain4.com"}),
+		)
+		err := req.ValidateSearchDomainFilter()
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrSearchDomainFilter, err)
+	})
+}
+
+func TestValidateImageDomainFilter(t *testing.T) {
+	validator := perplexity.NewRequestValidator()
+
+	t.Run("returns no error for empty filter", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+		)
+		// Test through full validation since individual method is not exported
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for valid domains", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"example.com", "test.com"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for maximum allowed length", func(t *testing.T) {
+		domains := []string{
+			"domain1.com", "domain2.com", "domain3.com", "domain4.com", "domain5.com",
+			"domain6.com", "domain7.com", "domain8.com", "domain9.com", "domain10.com",
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter(domains),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error for exceeding maximum length", func(t *testing.T) {
+		domains := []string{
+			"domain1.com", "domain2.com", "domain3.com", "domain4.com", "domain5.com",
+			"domain6.com", "domain7.com", "domain8.com", "domain9.com", "domain10.com",
+			"domain11.com",
+		}
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter(domains),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterTooLong, err)
+	})
+
+	t.Run("returns error for empty domain entry", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"example.com", "", "test.com"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterEmpty, err)
+	})
+
+	t.Run("returns error for domain with protocol", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"https://example.com"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterProtocolNotAllowed, err)
+	})
+
+	t.Run("returns error for domain with http protocol", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"http://example.com"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterProtocolNotAllowed, err)
+	})
+
+	t.Run("returns error for domain with subdomain", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"sub.example.com"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterSubdomainNotAllowed, err)
+	})
+
+	t.Run("returns error for invalid domain format", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"invalid@domain"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterInvalidFormat, err)
+	})
+
+	t.Run("returns no error for exclusion prefix domain", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"-gettyimages.com"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error for invalid exclusion prefix domain", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"-invalid@domain"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterInvalidFormat, err)
+	})
+}
+
+func TestValidateImageFormatFilter(t *testing.T) {
+	validator := perplexity.NewRequestValidator()
+
+	t.Run("returns no error for empty filter", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for valid formats", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{"jpg", "png", "webp"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error for empty format entry", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{"jpg", "", "png"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageFormatFilterEmpty, err)
+	})
+
+	t.Run("returns error for format with dot prefix", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{".jpg"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageFormatFilterDotPrefixNotAllowed, err)
+	})
+
+	t.Run("returns error for uppercase format", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{"JPG"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageFormatFilterMustBeLowercase, err)
+	})
+
+	t.Run("returns error for format with special characters", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{"j-p-g"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageFormatFilterInvalidFormat, err)
+	})
+
+	t.Run("returns error for format with numbers only", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{"j@g"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageFormatFilterInvalidFormat, err)
+	})
+
+	t.Run("returns no error for valid alphanumeric format", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{"jpeg", "png", "webp", "gif", "bmp"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error for format with numbers", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageFormatFilter([]string{"jpg", "png", "webp", "gif", "bmp", "tiff", "svg"}),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+}
+
+func TestValidateSearchRecencyFilterWithImages(t *testing.T) {
+	t.Run("returns error when ReturnImages is true and SearchRecencyFilter is set", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithReturnImages(true),
+			perplexity.WithSearchRecencyFilter("day"),
+		)
+		err := req.ValidateSearchRecencyFilter()
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrSearchRecencyFilter, err)
+	})
+
+	t.Run("returns no error when ReturnImages is false and SearchRecencyFilter is set", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithReturnImages(false),
+			perplexity.WithSearchRecencyFilter("day"),
+		)
+		err := req.ValidateSearchRecencyFilter()
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns no error when ReturnImages is true and SearchRecencyFilter is empty", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithReturnImages(true),
+			perplexity.WithSearchRecencyFilter(""),
+		)
+		err := req.ValidateSearchRecencyFilter()
+		assert.NoError(t, err)
+	})
+}
+
+func TestValidateRegexAndImagesCompatibility(t *testing.T) {
+	validator := perplexity.NewRequestValidator()
+
+	t.Run("returns error when regex and images are used together", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel("sonar"),
+			perplexity.WithReturnImages(true),
+			perplexity.WithSearchRecencyFilter(""),
+			perplexity.WithRegexResponseFormat(`\d+`),
+		)
+		err := validator.ValidateRequest(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "regex and images are not compatible")
+	})
+
+	t.Run("returns no error when regex is used without images", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel("sonar"),
+			perplexity.WithReturnImages(false),
+			perplexity.WithRegexResponseFormat(`\d+`),
+		)
+		err := validator.ValidateRequest(req)
+		assert.NoError(t, err)
+	})
+}
+
+// Test backward compatibility methods
+func TestBackwardCompatibility(t *testing.T) {
+	t.Run("Validate method still works", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+		)
+		err := req.Validate()
+		assert.NoError(t, err)
+	})
+
+	t.Run("ValidateSearchDomainFilter method still works", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithSearchDomainFilter([]string{"domain1.com", "domain2.com", "domain3.com", "domain4.com"}),
+		)
+		err := req.ValidateSearchDomainFilter()
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrSearchDomainFilter, err)
+	})
+
+	t.Run("ValidateSearchRecencyFilter method still works", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithReturnImages(true),
+			perplexity.WithSearchRecencyFilter("day"),
+		)
+		err := req.ValidateSearchRecencyFilter()
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrSearchRecencyFilter, err)
+	})
+
+	t.Run("ValidateStructuredOutput method still works", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel("llama-3.1-sonar-small-128k-online"),
+			perplexity.WithJSONSchemaResponseFormat(map[string]interface{}{"type": "object"}),
+		)
+		err := req.ValidateStructuredOutput()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "structured output (response_format) is only available for the 'sonar' model")
+	})
+}
+
+func TestValidateRequestNil(t *testing.T) {
+	validator := perplexity.NewRequestValidator()
+
+	t.Run("returns error for nil request", func(t *testing.T) {
+		err := validator.ValidateRequest(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "request cannot be nil")
+		assert.Contains(t, err.Error(), "validation failed")
+	})
+}

--- a/perplexity_request_validator_test.go
+++ b/perplexity_request_validator_test.go
@@ -411,6 +411,39 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, perplexity.ErrImageDomainFilterInvalidFormat, err)
 	})
+
+	t.Run("returns error for domain with www prefix", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"www.example.com"}),
+		)
+		err := req.Validate()
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterWWWNotAllowed, err)
+	})
+
+	t.Run("returns error for domain with www prefix and exclusion", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"-www.example.com"}),
+		)
+		err := req.Validate()
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterWWWNotAllowed, err)
+	})
+
+	t.Run("returns error for domain with exclusion and http protocol", func(t *testing.T) {
+		req := perplexity.NewCompletionRequest(
+			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
+			perplexity.WithModel(perplexity.DefaultModel),
+			perplexity.WithImageDomainFilter([]string{"-http://example.com"}),
+		)
+		err := req.Validate()
+		assert.Error(t, err)
+		assert.Equal(t, perplexity.ErrImageDomainFilterProtocolNotAllowed, err)
+	})
 }
 
 func TestValidateImageFormatFilter(t *testing.T) {

--- a/perplexity_request_validator_test.go
+++ b/perplexity_request_validator_test.go
@@ -30,7 +30,7 @@ func TestValidate(t *testing.T) {
 	f("returns error if TopK is gt 2048", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopK(2049))
 	f("returns error if Temperature is gt 2", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTemperature(2.1))
 	f("returns error if TopP is gt 1", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithTopP(1.1))
-	f("returns error if SearchDomainFilter contains more than 3 elements", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2", "filter3", "filter4"}))
+	f("returns error if SearchDomainFilter contains more than 10 elements", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2", "filter3", "filter4", "filter5", "filte6", "filter7", "filter8", "filter9", "filter10", "filter11"}))
 	f("returns error return_images and searchRecencyFilter are set", false, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(10), perplexity.WithTemperature(0.5), perplexity.WithTopP(0.5), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2"}), perplexity.WithReturnImages(true), perplexity.WithReturnRelatedQuestions(true), perplexity.WithSearchRecencyFilter("filter"), perplexity.WithTopK(10))
 	f("returns no error", true, perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "hello"}}), perplexity.WithModel(perplexity.DefaultModel), perplexity.WithMaxTokens(10), perplexity.WithTemperature(0.5), perplexity.WithTopP(0.5), perplexity.WithSearchDomainFilter([]string{"filter1", "filter2"}), perplexity.WithReturnRelatedQuestions(true), perplexity.WithTopK(10))
 }
@@ -275,11 +275,11 @@ func TestValidateSearchDomainFilter(t *testing.T) {
 		req := perplexity.NewCompletionRequest(
 			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
 			perplexity.WithModel(perplexity.DefaultModel),
-			perplexity.WithSearchDomainFilter([]string{"domain1.com", "domain2.com", "domain3.com", "domain4.com"}),
+			perplexity.WithSearchDomainFilter([]string{"domain1.com", "domain2.com", "domain3.com", "domain4.com", "domain5.com", "domain6.com", "domain7.com", "domain8.com", "domain9.com", "domain10.com", "domain11.com"}),
 		)
 		err := req.ValidateSearchDomainFilter()
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrSearchDomainFilter, err)
+		assert.Equal(t, perplexity.ErrDomainFilterTooLong, err)
 	})
 }
 
@@ -333,7 +333,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := validator.ValidateRequest(req)
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterTooLong, err)
+		assert.Equal(t, perplexity.ErrDomainFilterTooLong, err)
 	})
 
 	t.Run("returns error for empty domain entry", func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := validator.ValidateRequest(req)
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterEmpty, err)
+		assert.Equal(t, perplexity.ErrDomainFilterEmpty, err)
 	})
 
 	t.Run("returns error for domain with protocol", func(t *testing.T) {
@@ -355,7 +355,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := validator.ValidateRequest(req)
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterProtocolNotAllowed, err)
+		assert.Equal(t, perplexity.ErrDomainFilterProtocolNotAllowed, err)
 	})
 
 	t.Run("returns error for domain with http protocol", func(t *testing.T) {
@@ -366,7 +366,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := validator.ValidateRequest(req)
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterProtocolNotAllowed, err)
+		assert.Equal(t, perplexity.ErrDomainFilterProtocolNotAllowed, err)
 	})
 
 	t.Run("returns error for domain with subdomain", func(t *testing.T) {
@@ -377,7 +377,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := validator.ValidateRequest(req)
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterSubdomainNotAllowed, err)
+		assert.Equal(t, perplexity.ErrDomainFilterSubdomainNotAllowed, err)
 	})
 
 	t.Run("returns error for invalid domain format", func(t *testing.T) {
@@ -388,7 +388,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := validator.ValidateRequest(req)
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterInvalidFormat, err)
+		assert.Equal(t, perplexity.ErrDomainFilterInvalidFormat, err)
 	})
 
 	t.Run("returns no error for exclusion prefix domain", func(t *testing.T) {
@@ -409,7 +409,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := validator.ValidateRequest(req)
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterInvalidFormat, err)
+		assert.Equal(t, perplexity.ErrDomainFilterInvalidFormat, err)
 	})
 
 	t.Run("returns error for domain with www prefix", func(t *testing.T) {
@@ -420,7 +420,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := req.Validate()
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterWWWNotAllowed, err)
+		assert.Equal(t, perplexity.ErrDomainFilterWWWNotAllowed, err)
 	})
 
 	t.Run("returns error for domain with www prefix and exclusion", func(t *testing.T) {
@@ -431,7 +431,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := req.Validate()
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterWWWNotAllowed, err)
+		assert.Equal(t, perplexity.ErrDomainFilterWWWNotAllowed, err)
 	})
 
 	t.Run("returns error for domain with exclusion and http protocol", func(t *testing.T) {
@@ -442,7 +442,7 @@ func TestValidateImageDomainFilter(t *testing.T) {
 		)
 		err := req.Validate()
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrImageDomainFilterProtocolNotAllowed, err)
+		assert.Equal(t, perplexity.ErrDomainFilterProtocolNotAllowed, err)
 	})
 }
 
@@ -623,11 +623,11 @@ func TestBackwardCompatibility(t *testing.T) {
 		req := perplexity.NewCompletionRequest(
 			perplexity.WithMessages([]perplexity.Message{{Role: "user", Content: "test"}}),
 			perplexity.WithModel(perplexity.DefaultModel),
-			perplexity.WithSearchDomainFilter([]string{"domain1.com", "domain2.com", "domain3.com", "domain4.com"}),
+			perplexity.WithSearchDomainFilter([]string{"domain1.com", "domain2.com", "domain3.com", "domain4.com", "domain5.com", "domain6.com", "domain7.com", "domain8.com", "domain9.com", "domain10.com", "domain11.com"}),
 		)
 		err := req.ValidateSearchDomainFilter()
 		assert.Error(t, err)
-		assert.Equal(t, perplexity.ErrSearchDomainFilter, err)
+		assert.Equal(t, perplexity.ErrDomainFilterTooLong, err)
 	})
 
 	t.Run("ValidateSearchRecencyFilter method still works", func(t *testing.T) {

--- a/perplexity_response.go
+++ b/perplexity_response.go
@@ -2,6 +2,7 @@ package perplexity
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 )
 
@@ -29,6 +30,7 @@ type CompletionResponse struct {
 	Object        string          `json:"object"`
 	Choices       []Choice        `json:"choices"`
 	SearchResults *[]SearchResult `json:"search_results,omitempty"`
+	Images        *[]Image        `json:"images,omitempty"`
 	// Deprecated: Use SearchResults instead for better structured data with titles, URLs, and metadata.
 	//go:deprecated
 	Citations *[]string `json:"citations,omitempty"`
@@ -40,6 +42,14 @@ type SearchResult struct {
 	URL         string  `json:"url"`
 	Date        *string `json:"date,omitempty"`
 	LastUpdated *string `json:"last_updated,omitempty"`
+}
+
+// Image represents a single image in the Perplexity API response.
+type Image struct {
+	ImageURL  string `json:"image_url"`
+	OriginURL string `json:"origin_url"`
+	Height    int    `json:"height"`
+	Width     int    `json:"width"`
 }
 
 // String returns a string representation of the SearchResult.
@@ -57,6 +67,23 @@ func (sr *SearchResult) String() string {
 	}
 	if sr.LastUpdated != nil {
 		result += " (updated: " + *sr.LastUpdated + ")"
+	}
+
+	return result
+}
+
+// String returns a string representation of the Image.
+func (img *Image) String() string {
+	if img == nil {
+		return ""
+	}
+
+	result := img.ImageURL
+	if img.OriginURL != "" {
+		result += " (from: " + img.OriginURL + ")"
+	}
+	if img.Width > 0 && img.Height > 0 {
+		result += fmt.Sprintf(" [%dx%d]", img.Width, img.Height)
 	}
 
 	return result
@@ -102,4 +129,12 @@ func (r *CompletionResponse) GetSearchResults() []SearchResult {
 		return []SearchResult{}
 	}
 	return *r.SearchResults
+}
+
+// GetImages returns the images of the completion response.
+func (r *CompletionResponse) GetImages() []Image {
+	if r.Images == nil {
+		return []Image{}
+	}
+	return *r.Images
 }

--- a/perplexity_response_test.go
+++ b/perplexity_response_test.go
@@ -187,3 +187,78 @@ func TestSearchResultString(t *testing.T) {
 		assert.Equal(t, "Test Article (https://example.com/article) - 2024-01-01 (updated: 2024-01-02)", sr.String())
 	})
 }
+
+func TestImageString(t *testing.T) {
+	t.Run("nil image returns empty string", func(t *testing.T) {
+		var img *perplexity.Image
+		assert.Equal(t, "", img.String())
+	})
+
+	t.Run("image with URL only", func(t *testing.T) {
+		img := &perplexity.Image{
+			ImageURL: "https://example.com/image.png",
+		}
+		assert.Equal(t, "https://example.com/image.png", img.String())
+	})
+
+	t.Run("image with URL and origin URL", func(t *testing.T) {
+		img := &perplexity.Image{
+			ImageURL:  "https://example.com/image.png",
+			OriginURL: "https://example.com/source",
+		}
+		assert.Equal(t, "https://example.com/image.png (from: https://example.com/source)", img.String())
+	})
+
+	t.Run("image with URL, origin URL, and dimensions", func(t *testing.T) {
+		img := &perplexity.Image{
+			ImageURL:  "https://example.com/image.png",
+			OriginURL: "https://example.com/source",
+			Width:     2016,
+			Height:    1512,
+		}
+		assert.Equal(t, "https://example.com/image.png (from: https://example.com/source) [2016x1512]", img.String())
+	})
+
+	t.Run("image with URL and dimensions only", func(t *testing.T) {
+		img := &perplexity.Image{
+			ImageURL: "https://example.com/image.png",
+			Width:    800,
+			Height:   600,
+		}
+		assert.Equal(t, "https://example.com/image.png [800x600]", img.String())
+	})
+}
+
+func TestGetImages(t *testing.T) {
+	t.Run("empty response returns empty images", func(t *testing.T) {
+		content := perplexity.CompletionResponse{}
+		assert.Equal(t, content.GetImages(), []perplexity.Image{})
+	})
+
+	t.Run("nil images returns empty images", func(t *testing.T) {
+		content := perplexity.CompletionResponse{
+			Images: nil,
+		}
+		assert.Equal(t, content.GetImages(), []perplexity.Image{})
+	})
+
+	t.Run("case with real images", func(t *testing.T) {
+		images := []perplexity.Image{
+			{
+				ImageURL:  "https://content-management-files.canva.com/cdn-cgi/image/f=auto,q=70/b94ec02b-ed6a-47ce-80fc-7eb2d5679e90/ai-face-generator_promo-showcase_012x.png",
+				OriginURL: "https://www.canva.com/ai-face-generator/",
+				Height:    1512,
+				Width:     2016,
+			},
+			{
+				ImageURL: "https://example.com/another-image.jpg",
+				Width:    800,
+				Height:   600,
+			},
+		}
+		content := perplexity.CompletionResponse{
+			Images: &images,
+		}
+		assert.Equal(t, content.GetImages(), images)
+	})
+}


### PR DESCRIPTION
* added image filters to completionRequest: image_format_filter and image_domain_filter
* added images to completionResult
* fixed a bug in main.go where the StructuredOutput for regex was configuring SSE but sending a normal completion
* pulled demo examples in main into their own functions for readability.
* after adding more validation, the validation was getting super beefy so i moved it into its own file. and created a validator type.