### PR TITLE
feat: Open up requests with response format to models other than just sonar no message

### DIFF
--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -61,7 +61,7 @@ type CompletionRequest struct {
 	// Required range: 0 < x < 1
 	TopP float64 `json:"top_p" validate:"gt=0,lt=1"`
 	// SearchDomainFilter: Given a list of domains, limit the citations used by the online model
-	// to URLs from the specified domains. Currently limited to only 3 domains for allowlisting and denylisting.
+	// to URLs from the specified domains. Not to exceed 10 domains for allowlisting and denylisting.
 	// For denylisting add a - to the beginning of the domain string. This filter is in closed beta
 	SearchDomainFilter []string `json:"search_domain_filter"`
 	// ReturnImages: Determines whether or not a request to an online model
@@ -102,11 +102,8 @@ type CompletionRequest struct {
 
 	// ResponseFormat: Optional. Controls the format of the response output.
 	// Supports JSON Schema and Regex formats for structured outputs.
-	// Only available for the "sonar" model.
 	ResponseFormat *ResponseFormat `json:"response_format,omitempty" validate:"omitempty"`
 
-	// ImageDomainFilter: Optional. Controls the domain filter for images.
-	// Only available for the "sonar" model.
 	// ImageDomainFilter: Optional. Controls the domain filter for images.
 	// Domain Filtering:
 	//   - prepending the url with - will exclude the domain
@@ -121,7 +118,6 @@ type CompletionRequest struct {
 	ImageDomainFilter []string `json:"image_domain_filter,omitempty" validate:"omitempty"`
 
 	// ImageFormatFilter: Optional. Controls the format filter for images.
-	// Only available for the "sonar" model.
 	ImageFormatFilter []string `json:"image_format_filter,omitempty" validate:"omitempty"`
 
 	// SearchAfterDateFilter: Optional. Filters search results to include content published after a specific date.
@@ -387,7 +383,6 @@ func WithResponseFormat(format *ResponseFormat) CompletionRequestOption {
 
 // WithJSONSchemaResponseFormat sets the response format to JSON Schema.
 // The schema parameter can be a Go struct, map, or any valid JSON schema.
-// Only available for the "sonar" model.
 func WithJSONSchemaResponseFormat(schema interface{}) CompletionRequestOption {
 	return func(r *CompletionRequest) {
 		r.ResponseFormat = &ResponseFormat{
@@ -401,7 +396,6 @@ func WithJSONSchemaResponseFormat(schema interface{}) CompletionRequestOption {
 
 // WithRegexResponseFormat sets the response format to Regex.
 // The regex parameter should be a valid regular expression pattern.
-// Only available for the "sonar" model.
 func WithRegexResponseFormat(regex string) CompletionRequestOption {
 	return func(r *CompletionRequest) {
 		r.ResponseFormat = &ResponseFormat{
@@ -435,7 +429,6 @@ func WithImageDomainFilter(domains []string) CompletionRequestOption {
 
 // WithImageFormatFilter sets the image format filter option.
 // Controls which image formats to include in the response.
-// Only available for the "sonar" model.
 func WithImageFormatFilter(formats []string) CompletionRequestOption {
 	return func(r *CompletionRequest) {
 		r.ImageFormatFilter = formats

--- a/perplexity_request_validator.go
+++ b/perplexity_request_validator.go
@@ -28,9 +28,6 @@ var (
 	// ErrValidationFailed is returned when struct validation fails.
 	ErrValidationFailed = errors.New("validation failed")
 
-	// ErrStructuredOutputModelRequirement is returned when structured output is used with an unsupported model.
-	ErrStructuredOutputModelRequirement = errors.New("structured output (response_format) is only available for the 'sonar' model")
-
 	// ErrStructuredOutputFormatMismatch is returned when the response format configuration doesn't match the type.
 	ErrStructuredOutputFormatMismatch = errors.New("response format type must match the provided configuration (json_schema or regex)")
 
@@ -148,22 +145,10 @@ func (v *RequestValidator) validateStructuredOutput(req *CompletionRequest) erro
 		return nil
 	}
 
-	if err := v.validateStructuredOutputModel(req); err != nil {
-		return err
-	}
-
 	if err := v.validateStructuredOutputFormat(req); err != nil {
 		return err
 	}
 
-	return nil
-}
-
-// validateStructuredOutputModel validates that the model supports structured output.
-func (v *RequestValidator) validateStructuredOutputModel(req *CompletionRequest) error {
-	if req.Model != "sonar" {
-		return ErrStructuredOutputModelRequirement
-	}
 	return nil
 }
 

--- a/perplexity_request_validator_test.go
+++ b/perplexity_request_validator_test.go
@@ -101,7 +101,7 @@ func TestStructuredOutputValidation(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("rejects structured output with non-sonar model", func(t *testing.T) {
+	t.Run("allows structured output with any model", func(t *testing.T) {
 		msg := []perplexity.Message{
 			{
 				Role:    "user",
@@ -117,8 +117,7 @@ func TestStructuredOutputValidation(t *testing.T) {
 			perplexity.WithJSONSchemaResponseFormat(schema),
 		)
 		err := validator.ValidateRequest(req)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "structured output (response_format) is only available for the 'sonar' model")
+		assert.NoError(t, err)
 	})
 
 	t.Run("rejects invalid json_schema configuration", func(t *testing.T) {
@@ -688,8 +687,7 @@ func TestBackwardCompatibility(t *testing.T) {
 			perplexity.WithJSONSchemaResponseFormat(map[string]interface{}{"type": "object"}),
 		)
 		err := req.ValidateStructuredOutput()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "structured output (response_format) is only available for the 'sonar' model")
+		assert.NoError(t, err)
 	})
 }
 

--- a/perplexity_response.go
+++ b/perplexity_response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // Usage is a usage object for the Perplexity API.
@@ -146,4 +147,28 @@ func (r *CompletionResponse) GetRelatedQuestions() []string {
 		return []string{}
 	}
 	return *r.RelatedQuestions
+}
+
+// GetPostThinkingContent returns the content that comes after the thinking section in reasoning model responses.
+// For reasoning models like sonar-reasoning or sonar-reasoning-pro, the response often contains a <think>...</think>
+// section followed by the actual formatted response. This method extracts only the content after the thinking section.
+// If no thinking section is found, it returns the original content unchanged.
+func (r *CompletionResponse) GetPostThinkingContent() string {
+	content := r.GetLastContent()
+	return extractPostThinkingContent(content)
+}
+
+// extractPostThinkingContent extracts content that comes after the last </think> tag.
+// If no </think> tag is found, returns the original content.
+func extractPostThinkingContent(content string) string {
+	// Find the last closing </think> tag
+	thinkEnd := strings.LastIndex(content, "</think>")
+	if thinkEnd == -1 {
+		// No thinking section, return original content
+		return content
+	}
+
+	// Return everything after </think>, trimmed of whitespace
+	result := strings.TrimSpace(content[thinkEnd+8:]) // 8 = len("</think>")
+	return result
 }

--- a/perplexity_response_test.go
+++ b/perplexity_response_test.go
@@ -290,3 +290,168 @@ func TestGetRelatedQuestions(t *testing.T) {
 		assert.Equal(t, content.GetRelatedQuestions(), relatedQuestions)
 	})
 }
+
+func TestGetPostThinkingContent(t *testing.T) {
+	t.Run("empty response returns empty string", func(t *testing.T) {
+		response := perplexity.CompletionResponse{}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, "", content)
+	})
+
+	t.Run("no choices returns empty string", func(t *testing.T) {
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, "", content)
+	})
+
+	t.Run("content without thinking section returns original content", func(t *testing.T) {
+		originalContent := "This is a regular response without thinking."
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: originalContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, originalContent, content)
+	})
+
+	t.Run("content with thinking section returns post-thinking content", func(t *testing.T) {
+		fullContent := "<think>I need to analyze this question carefully. Let me think about the best approach...</think>\n\nThis is the final answer after thinking."
+		expectedContent := "This is the final answer after thinking."
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: fullContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, expectedContent, content)
+	})
+
+	t.Run("content with thinking section and extra whitespace", func(t *testing.T) {
+		fullContent := "<think>Let me think about this...</think>   \n\n  Final answer with extra whitespace.  \n\n"
+		expectedContent := "Final answer with extra whitespace."
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: fullContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, expectedContent, content)
+	})
+
+	t.Run("content with multiple thinking sections returns content after last one", func(t *testing.T) {
+		fullContent := "<think>First thought</think>Some content<think>Second thought</think>\n\nFinal answer."
+		expectedContent := "Final answer."
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: fullContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, expectedContent, content)
+	})
+
+	t.Run("content with only opening think tag returns original content", func(t *testing.T) {
+		fullContent := "<think>This thinking section never closes..."
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: fullContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, fullContent, content)
+	})
+
+	t.Run("content with nested or complex thinking sections", func(t *testing.T) {
+		fullContent := "<think>I need to think about this <nested>tag</nested> carefully.</think>\n\n{\"answer\": \"This is JSON formatted response\"}"
+		expectedContent := "{\"answer\": \"This is JSON formatted response\"}"
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: fullContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, expectedContent, content)
+	})
+
+	t.Run("content with empty post-thinking section", func(t *testing.T) {
+		fullContent := "<think>I'm thinking...</think>"
+		expectedContent := ""
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: fullContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, expectedContent, content)
+	})
+
+	t.Run("multiple choices returns content from last choice", func(t *testing.T) {
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: "<think>First choice thinking</think>First choice answer",
+					},
+				},
+				{
+					Message: perplexity.Message{
+						Content: "<think>Second choice thinking</think>Second choice answer",
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, "Second choice answer", content)
+	})
+
+	t.Run("real world example with reasoning model response", func(t *testing.T) {
+		fullContent := `<think>
+The user is asking about the capital of France. This is a straightforward geography question. The capital of France is Paris. I should provide a clear, accurate answer.
+</think>
+
+The capital of France is Paris. Paris is not only the political capital but also the largest city in France, serving as the country's economic, cultural, and administrative center.`
+		expectedContent := "The capital of France is Paris. Paris is not only the political capital but also the largest city in France, serving as the country's economic, cultural, and administrative center."
+		response := perplexity.CompletionResponse{
+			Choices: []perplexity.Choice{
+				{
+					Message: perplexity.Message{
+						Content: fullContent,
+					},
+				},
+			},
+		}
+		content := response.GetPostThinkingContent()
+		assert.Equal(t, expectedContent, content)
+	})
+}


### PR DESCRIPTION
* removed sonar constraint when using response formats
* added helper method to get the content after the think section: GetPostThinkingContent.
* removed some incorrect comments

fixes #89 