### PR TITLE
ci: update go version to >= 1.25 in all workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.22
+          go-version: '>= 1.25'
   
       - name: coverage
         id: coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.23.x
+          go-version: '>= 1.25'
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.22
+          go-version: '>= 1.25'
 
       - name: Cache Go modules
         uses: actions/cache@v4


### PR DESCRIPTION
ci: update go version to >= 1.25 in all workflows
