### PR TITLE
fix(validation): accept base64 data URIs for files and images

### DIFF
--- a/perplexity_file.go
+++ b/perplexity_file.go
@@ -41,6 +41,9 @@ var (
 	// ErrFileURLInvalid is returned when a file URL is malformed.
 	ErrFileURLInvalid = errors.New("invalid file URL format")
 
+	// ErrFileDataURIMalformed is returned when a file data URI is malformed.
+	ErrFileDataURIMalformed = errors.New("invalid file data URI")
+
 	// ErrFileURLBadStatus is returned when file URL returns a non-2xx status.
 	ErrFileURLBadStatus = errors.New("file URL returned bad status")
 
@@ -101,11 +104,16 @@ func (p *FileProcessor) EncodeFileFromPath(filePath string) (string, string, err
 	return base64Data, fileName, nil
 }
 
-// ValidateFileURL validates that a URL is HTTPS and has a valid format.
-// The URL must use HTTPS protocol to be accepted by the Perplexity API.
+// ValidateFileURL validates that a URL is HTTPS (or a base64 data URI) and has a valid format.
+// Accepts either an https:// URL or a data:<mime>;base64,<payload> URI, matching what the
+// Perplexity API accepts for embedded files.
 func (p *FileProcessor) ValidateFileURL(fileURL string) error {
 	if fileURL == "" {
 		return ErrFileURLInvalid
+	}
+
+	if strings.HasPrefix(fileURL, "data:") {
+		return p.validateFileDataURI(fileURL)
 	}
 
 	// Parse the URL
@@ -177,6 +185,21 @@ func (p *FileProcessor) CheckFileURLAccessibility(ctx context.Context, fileURL s
 	return nil
 }
 
+// validateFileDataURI validates a data:<mime>;base64,<payload> URI for supported file formats.
+func (p *FileProcessor) validateFileDataURI(uri string) error {
+	mime, decoded, err := parseBase64DataURI(uri)
+	if err != nil {
+		return ErrFileDataURIMalformed
+	}
+
+	format := p.getFileFormatFromMime(mime)
+	if err := p.ValidateFileFormat(format); err != nil {
+		return err
+	}
+
+	return p.ValidateFileSize(int64(len(decoded)))
+}
+
 // getFileFormatFromPath extracts the file format from a file path.
 func (p *FileProcessor) getFileFormatFromPath(path string) string {
 	ext := filepath.Ext(path)
@@ -184,6 +207,44 @@ func (p *FileProcessor) getFileFormatFromPath(path string) string {
 		return strings.ToLower(ext[1:]) // Remove the dot and convert to lowercase
 	}
 	return ""
+}
+
+// getFileMimeType returns the canonical MIME type for a given supported file format.
+// Returns an empty string for unsupported formats.
+func (p *FileProcessor) getFileMimeType(format string) string {
+	switch strings.ToLower(format) {
+	case "pdf":
+		return "application/pdf"
+	case "doc":
+		return "application/msword"
+	case "docx":
+		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	case "txt":
+		return "text/plain"
+	case "rtf":
+		return "application/rtf"
+	default:
+		return ""
+	}
+}
+
+// getFileFormatFromMime returns the supported file format (e.g. "pdf") for a canonical mime type.
+// Returns an empty string for mime types that don't map to a supported format.
+func (p *FileProcessor) getFileFormatFromMime(mime string) string {
+	switch strings.ToLower(mime) {
+	case "application/pdf":
+		return "pdf"
+	case "application/msword":
+		return "doc"
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return "docx"
+	case "text/plain":
+		return "txt"
+	case "application/rtf", "text/rtf":
+		return "rtf"
+	default:
+		return ""
+	}
 }
 
 // isValidFileContentType checks if a content type corresponds to a supported file format.

--- a/perplexity_file_test.go
+++ b/perplexity_file_test.go
@@ -2,6 +2,7 @@ package perplexity_test
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -85,6 +86,8 @@ func TestValidateFileSize(t *testing.T) {
 func TestValidateFileURL(t *testing.T) {
 	processor := perplexity.NewFileProcessor()
 
+	payload := base64.StdEncoding.EncodeToString([]byte("file bytes"))
+
 	tests := []struct {
 		name    string
 		url     string
@@ -98,6 +101,27 @@ func TestValidateFileURL(t *testing.T) {
 		{"invalid URL", "not-a-url", true, perplexity.ErrFileURLNotHTTPS},
 		{"no host", "https://", true, perplexity.ErrFileURLInvalid},
 		{"ftp protocol", "ftp://example.com/file.pdf", true, perplexity.ErrFileURLNotHTTPS},
+
+		// Valid data URIs for each supported format.
+		{"valid data URI pdf", "data:application/pdf;base64," + payload, false, nil},
+		{"valid data URI doc", "data:application/msword;base64," + payload, false, nil},
+		{"valid data URI docx",
+			"data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64," + payload,
+			false, nil},
+		{"valid data URI txt", "data:text/plain;base64," + payload, false, nil},
+		{"valid data URI rtf (application/rtf)", "data:application/rtf;base64," + payload, false, nil},
+		{"valid data URI rtf (text/rtf)", "data:text/rtf;base64," + payload, false, nil},
+		{"valid data URI mixed case mime", "data:APPLICATION/PDF;base64," + payload, false, nil},
+
+		// Unsupported data URI mimes.
+		{"data URI unsupported mime", "data:application/json;base64," + payload, true, perplexity.ErrFileFormatNotSupported},
+		{"data URI image mime", "data:image/png;base64," + payload, true, perplexity.ErrFileFormatNotSupported},
+
+		// Malformed data URIs.
+		{"data URI empty payload", "data:application/pdf;base64,", true, perplexity.ErrFileDataURIMalformed},
+		{"data URI empty mime", "data:;base64,YWJj", true, perplexity.ErrFileDataURIMalformed},
+		{"data URI missing separator", "data:application/pdf,YWJj", true, perplexity.ErrFileDataURIMalformed},
+		{"data URI invalid base64", "data:application/pdf;base64,!!!not-base64!!!", true, perplexity.ErrFileDataURIMalformed},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +137,16 @@ func TestValidateFileURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateFileURLOversizedDataURI(t *testing.T) {
+	processor := perplexity.NewFileProcessor()
+
+	oversized := make([]byte, perplexity.MaxFileSizeBytes+1)
+	uri := "data:application/pdf;base64," + base64.StdEncoding.EncodeToString(oversized)
+	err := processor.ValidateFileURL(uri)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, perplexity.ErrFileTooLarge)
 }
 
 func TestEncodeFileFromPath(t *testing.T) {
@@ -223,4 +257,41 @@ func TestSupportedFileFormats(t *testing.T) {
 		assert.Contains(t, formats, "rtf")
 		assert.Len(t, formats, 5)
 	})
+}
+
+// TestValidateRequestWithLocalImageFile reproduces the bug report:
+// NewImageFileContent produces a data URI, and req.Validate() must accept it.
+// SearchRecencyFilter is explicitly cleared because NewCompletionRequest defaults it to "month",
+// which is (separately) rejected by validateImageCompatibility — unrelated to this fix.
+func TestValidateRequestWithLocalImageFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	imgPath := filepath.Join(tmpDir, "local.jpg")
+	require.NoError(t, os.WriteFile(imgPath, []byte("fake-jpeg-bytes"), 0600))
+
+	msgs := perplexity.NewMessages()
+	require.NoError(t, msgs.AddUserMessageWithImageFile("describe this", imgPath))
+
+	req := perplexity.NewCompletionRequest(
+		perplexity.WithMessagesFromMessages(&msgs),
+		perplexity.WithModel("sonar-pro"),
+		perplexity.WithSearchRecencyFilter(""),
+	)
+	assert.NoError(t, req.Validate())
+}
+
+// TestValidateRequestWithLocalFile reproduces the analogous file-path bug:
+// NewFileFileContent produces a data URI and req.Validate() must accept it.
+func TestValidateRequestWithLocalFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "report.pdf")
+	require.NoError(t, os.WriteFile(filePath, []byte("%PDF-1.4\nfake"), 0600))
+
+	msgs := perplexity.NewMessages()
+	require.NoError(t, msgs.AddUserMessageWithFileFromPath("summarize", filePath))
+
+	req := perplexity.NewCompletionRequest(
+		perplexity.WithMessagesFromMessages(&msgs),
+		perplexity.WithModel("sonar-pro"),
+	)
+	assert.NoError(t, req.Validate())
 }

--- a/perplexity_image.go
+++ b/perplexity_image.go
@@ -44,6 +44,9 @@ var (
 	// ErrImageURLInvalid is returned when an image URL is malformed.
 	ErrImageURLInvalid = errors.New("invalid image URL format")
 
+	// ErrImageDataURIMalformed is returned when an image data URI is malformed.
+	ErrImageDataURIMalformed = errors.New("invalid image data URI")
+
 	// ErrImageURLBadStatus is returned when image URL returns a non-2xx status.
 	ErrImageURLBadStatus = errors.New("image URL returned bad status")
 
@@ -102,11 +105,16 @@ func (p *ImageProcessor) EncodeImageFromFile(filepath string) (string, error) {
 	return dataURI, nil
 }
 
-// ValidateImageURL validates that a URL is HTTPS and has a valid format.
-// The URL must use HTTPS protocol to be accepted by the Perplexity API.
+// ValidateImageURL validates that a URL is HTTPS (or a base64 data URI) and has a valid format.
+// Accepts either an https:// URL or a data:image/<fmt>;base64,<payload> URI, matching what the
+// Perplexity API accepts and what EncodeImageFromFile produces.
 func (p *ImageProcessor) ValidateImageURL(imageURL string) error {
 	if imageURL == "" {
 		return ErrImageURLInvalid
+	}
+
+	if strings.HasPrefix(imageURL, "data:") {
+		return p.validateImageDataURI(imageURL)
 	}
 
 	// Parse the URL
@@ -188,6 +196,25 @@ func (p *ImageProcessor) EstimateTokenUsage(width, height int) int {
 	return (width * height) / TokenEstimationDivisor
 }
 
+// validateImageDataURI validates a data:image/<fmt>;base64,<payload> URI.
+func (p *ImageProcessor) validateImageDataURI(uri string) error {
+	mime, decoded, err := parseBase64DataURI(uri)
+	if err != nil {
+		return ErrImageDataURIMalformed
+	}
+
+	// Mime must start with "image/" and the suffix must be a supported format.
+	format, ok := strings.CutPrefix(mime, "image/")
+	if !ok {
+		return ErrImageFormatNotSupported
+	}
+	if err := p.ValidateImageFormat(format); err != nil {
+		return err
+	}
+
+	return p.ValidateImageSize(int64(len(decoded)))
+}
+
 // getImageFormatFromPath extracts the image format from a file path.
 func (p *ImageProcessor) getImageFormatFromPath(path string) string {
 	ext := filepath.Ext(path)
@@ -211,6 +238,38 @@ func (p *ImageProcessor) getMimeType(format string) string {
 	default:
 		return "image/" + format
 	}
+}
+
+// errDataURIMalformed is an internal sentinel for parseBase64DataURI failures.
+// Callers map this to their module-specific public error (ErrImageDataURIMalformed, ErrFileDataURIMalformed).
+var errDataURIMalformed = errors.New("malformed data URI")
+
+// parseBase64DataURI parses a "data:<mime>;base64,<payload>" URI.
+// Returns the lowercased mime and decoded bytes, or errDataURIMalformed on any parse failure
+// (missing prefix, missing ";base64," separator, empty mime, empty payload, invalid base64).
+func parseBase64DataURI(uri string) (string, []byte, error) {
+	const prefix = "data:"
+	const sep = ";base64,"
+
+	if !strings.HasPrefix(uri, prefix) {
+		return "", nil, errDataURIMalformed
+	}
+	rest := uri[len(prefix):]
+
+	rawMime, payload, ok := strings.Cut(rest, sep)
+	if !ok {
+		return "", nil, errDataURIMalformed
+	}
+	mime := strings.ToLower(rawMime)
+	if mime == "" || payload == "" {
+		return "", nil, errDataURIMalformed
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", nil, errDataURIMalformed
+	}
+	return mime, decoded, nil
 }
 
 // isValidImageContentType checks if a content type corresponds to a supported image format.

--- a/perplexity_image_test.go
+++ b/perplexity_image_test.go
@@ -1,6 +1,7 @@
 package perplexity_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/sgaunet/perplexity-go/v2"
@@ -63,6 +64,59 @@ func TestImageProcessor(t *testing.T) {
 			err := processor.ValidateImageURL(url)
 			assert.Error(t, err, "URL %s should be invalid", url)
 		}
+	})
+
+	t.Run("ValidateImageURL with valid data URIs", func(t *testing.T) {
+		payload := base64.StdEncoding.EncodeToString([]byte("tiny image bytes"))
+		validDataURIs := []string{
+			"data:image/png;base64," + payload,
+			"data:image/jpeg;base64," + payload,
+			"data:image/webp;base64," + payload,
+			"data:image/gif;base64," + payload,
+			"data:IMAGE/PNG;base64," + payload, // mime is case-insensitive
+		}
+		for _, uri := range validDataURIs {
+			err := processor.ValidateImageURL(uri)
+			assert.NoError(t, err, "data URI %q should be valid", uri[:40])
+		}
+	})
+
+	t.Run("ValidateImageURL with unsupported data URI mime", func(t *testing.T) {
+		payload := base64.StdEncoding.EncodeToString([]byte("bytes"))
+		cases := []string{
+			"data:image/bmp;base64," + payload,    // unsupported image mime
+			"data:image/tiff;base64," + payload,   // unsupported image mime
+			"data:application/pdf;base64," + payload, // non-image mime
+			"data:text/plain;base64," + payload,   // non-image mime
+		}
+		for _, uri := range cases {
+			err := processor.ValidateImageURL(uri)
+			assert.Error(t, err, "data URI %q should be rejected", uri)
+			assert.ErrorIs(t, err, perplexity.ErrImageFormatNotSupported)
+		}
+	})
+
+	t.Run("ValidateImageURL with malformed data URIs", func(t *testing.T) {
+		cases := []string{
+			"data:image/png;base64,",          // empty payload
+			"data:;base64,YWJj",               // empty mime
+			"data:image/png,YWJj",             // missing ";base64," separator
+			"data:image/png;base64,!!!not-base64!!!", // invalid base64 payload
+			"data:image/png;base64,YWJj==extra", // trailing garbage => decode fails
+		}
+		for _, uri := range cases {
+			err := processor.ValidateImageURL(uri)
+			assert.Error(t, err, "data URI %q should be malformed", uri)
+			assert.ErrorIs(t, err, perplexity.ErrImageDataURIMalformed)
+		}
+	})
+
+	t.Run("ValidateImageURL with oversized data URI payload", func(t *testing.T) {
+		oversized := make([]byte, perplexity.MaxImageSizeBytes+1)
+		uri := "data:image/png;base64," + base64.StdEncoding.EncodeToString(oversized)
+		err := processor.ValidateImageURL(uri)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, perplexity.ErrImageTooLarge)
 	})
 
 	t.Run("EstimateTokenUsage", func(t *testing.T) {

--- a/perplexity_msg.go
+++ b/perplexity_msg.go
@@ -1,6 +1,9 @@
 package perplexity
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // ContentType represents the type of content in a multimodal message.
 type ContentType string
@@ -83,7 +86,8 @@ func NewFileURLContent(url string, fileName string) Content {
 	return content
 }
 
-// NewFileFileContent creates file content from a file path by encoding it to base64.
+// NewFileFileContent creates file content from a file path by encoding it to a base64 data URI.
+// The resulting URL field contains a "data:<mime>;base64,<payload>" URI accepted by the Perplexity API.
 func NewFileFileContent(filepath string) (Content, error) {
 	processor := NewFileProcessor()
 	base64Data, fileName, err := processor.EncodeFileFromPath(filepath)
@@ -91,7 +95,10 @@ func NewFileFileContent(filepath string) (Content, error) {
 		return Content{}, err
 	}
 
-	return NewFileURLContent(base64Data, fileName), nil
+	format := processor.getFileFormatFromPath(filepath)
+	mime := processor.getFileMimeType(format)
+	dataURI := fmt.Sprintf("data:%s;base64,%s", mime, base64Data)
+	return NewFileURLContent(dataURI, fileName), nil
 }
 
 // Error definitions.


### PR DESCRIPTION
- ValidateImageURL and ValidateFileURL now accept data:<mime>;base64,<payload> URIs
- Add shared parseBase64DataURI helper with size and base64 validation
- Add ErrImageDataURIMalformed and ErrFileDataURIMalformed sentinels
- NewFileFileContent now emits a proper data URI instead of raw base64
- Add regression tests covering the req.Validate() bug with local attachments

Closes #128