### PR TITLE
fix(request): drop default search_recency_filter

### DIFF
--- a/perplexity_file_test.go
+++ b/perplexity_file_test.go
@@ -261,8 +261,6 @@ func TestSupportedFileFormats(t *testing.T) {
 
 // TestValidateRequestWithLocalImageFile reproduces the bug report:
 // NewImageFileContent produces a data URI, and req.Validate() must accept it.
-// SearchRecencyFilter is explicitly cleared because NewCompletionRequest defaults it to "month",
-// which is (separately) rejected by validateImageCompatibility — unrelated to this fix.
 func TestValidateRequestWithLocalImageFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	imgPath := filepath.Join(tmpDir, "local.jpg")
@@ -274,7 +272,6 @@ func TestValidateRequestWithLocalImageFile(t *testing.T) {
 	req := perplexity.NewCompletionRequest(
 		perplexity.WithMessagesFromMessages(&msgs),
 		perplexity.WithModel("sonar-pro"),
-		perplexity.WithSearchRecencyFilter(""),
 	)
 	assert.NoError(t, req.Validate())
 }

--- a/perplexity_request.go
+++ b/perplexity_request.go
@@ -25,8 +25,8 @@ const (
 	// DefaultFrequencyPenalty is the default frequency penalty value (0.0 to 1.0).
 	DefaultFrequencyPenalty = 1.0
 
-	// DefaultSearchRecencyFilter is the default search recency filter value.
-	DefaultSearchRecencyFilter = "month"
+	// DefaultSearchRecencyFilter is the default search recency filter value (empty = omitted from the request).
+	DefaultSearchRecencyFilter = ""
 
 	// DefaultSearchMode is the default search mode value.
 	DefaultSearchMode = "web"

--- a/perplexity_test.go
+++ b/perplexity_test.go
@@ -49,7 +49,7 @@ func TestGetCompletion(t *testing.T) {
 				defer r.Body.Close()
 				b, err := io.ReadAll(r.Body)
 				assert.Nil(t, err)
-				assert.Equal(t, string(b), `{"messages":[{"role":"user","content":"What's the capital of France?"}],"model":"sonar","max_tokens":4000,"temperature":0.2,"top_p":0.9,"search_domain_filter":null,"return_images":false,"return_related_questions":false,"search_recency_filter":"month","search_mode":"web","top_k":0,"stream":false,"presence_penalty":0,"frequency_penalty":1}`)
+				assert.Equal(t, string(b), `{"messages":[{"role":"user","content":"What's the capital of France?"}],"model":"sonar","max_tokens":4000,"temperature":0.2,"top_p":0.9,"search_domain_filter":null,"return_images":false,"return_related_questions":false,"search_mode":"web","top_k":0,"stream":false,"presence_penalty":0,"frequency_penalty":1}`)
 				w.Header().Add("Content-Type", "application/json")
 				fmt.Fprintln(w, "{}")
 			}))
@@ -132,7 +132,7 @@ func TestSendSSEHTTPRequest(t *testing.T) {
 				defer r.Body.Close()
 				b, err := io.ReadAll(r.Body)
 				assert.Nil(t, err)
-				assert.Equal(t, string(b), `{"messages":[{"role":"user","content":"What's the capital of France?"}],"model":"sonar","max_tokens":4000,"temperature":0.2,"top_p":0.9,"search_domain_filter":null,"return_images":false,"return_related_questions":false,"search_recency_filter":"month","search_mode":"web","top_k":0,"stream":true,"presence_penalty":0,"frequency_penalty":1}`)
+				assert.Equal(t, string(b), `{"messages":[{"role":"user","content":"What's the capital of France?"}],"model":"sonar","max_tokens":4000,"temperature":0.2,"top_p":0.9,"search_domain_filter":null,"return_images":false,"return_related_questions":false,"search_mode":"web","top_k":0,"stream":true,"presence_penalty":0,"frequency_penalty":1}`)
 			}))
 		defer ts.Close()
 


### PR DESCRIPTION
- change DefaultSearchRecencyFilter from "month" to ""
- field is now omitted from outgoing JSON when unset
- remove workaround in image-file validation test
- update expected JSON payloads in completion/SSE tests

Closes #130