### PR TITLE
feat(streaming): add StreamCompletion API with backpressure

### DIFF
--- a/cmd/streaming-sse/main.go
+++ b/cmd/streaming-sse/main.go
@@ -1,12 +1,12 @@
 // Package main demonstrates Server-Sent Events (SSE) streaming with the Perplexity API.
-// This example shows how to handle real-time streaming responses using goroutines,
-// channels, and proper synchronization with sync.WaitGroup.
+// This example shows how to handle real-time streaming responses with StreamCompletion:
+// the client call runs in its own goroutine, the main goroutine consumes the channel,
+// and an error channel hands the final error back to main.
 package main
 
 import (
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/sgaunet/perplexity-go/v2"
 )
@@ -42,30 +42,15 @@ func main() {
 	fmt.Println("Streaming response:")
 	fmt.Println("---")
 
-	// Set up synchronization
-	var wg sync.WaitGroup
-	chResponses := make(chan perplexity.CompletionResponse, 5) // Buffered channel for responses
+	chResponses := make(chan perplexity.CompletionResponse)
+	errCh := make(chan error, 1)
 	fullResponse := perplexity.CompletionResponse{}
 
-	// Signal channel to ensure goroutine has started
-	waitAfterGoroutine := make(chan struct{})
-
-	// Start goroutine to handle SSE streaming
-	wg.Add(1)
+	// Run the streaming call in its own goroutine. StreamCompletion closes the
+	// channel before returning, so the range loop below exits cleanly.
 	go func() {
-		// Signal that goroutine has started
-		waitAfterGoroutine <- struct{}{}
-
-		// Send SSE request (this will stream responses to the channel)
-		err := client.SendSSEHTTPRequest(&wg, req, chResponses)
-		if err != nil {
-			fmt.Printf("\nError during streaming: %v\n", err)
-			os.Exit(1)
-		}
+		errCh <- client.StreamCompletion(req, chResponses)
 	}()
-
-	// Wait for goroutine to start
-	<-waitAfterGoroutine
 
 	// Process streaming responses as they arrive
 	tokenCount := 0
@@ -85,8 +70,10 @@ func main() {
 		tokenCount++
 	}
 
-	// Wait for all goroutines to complete
-	wg.Wait()
+	if err := <-errCh; err != nil {
+		fmt.Printf("\nError during streaming: %v\n", err)
+		os.Exit(1)
+	}
 
 	fmt.Println("\n---")
 	fmt.Printf("Streaming completed. Received %d response chunks.\n", tokenCount)

--- a/perplexity.go
+++ b/perplexity.go
@@ -148,17 +148,53 @@ func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *Comp
 	return r, nil
 }
 
+// StreamCompletion sends a completion request to the Perplexity API using Server-Sent Events.
+// It blocks until the stream ends or an error occurs, writing each event to responseChannel,
+// and closes responseChannel before returning.
+//
+// Typical usage: run this in its own goroutine and consume the channel from the caller:
+//
+//	ch := make(chan perplexity.CompletionResponse)
+//	errCh := make(chan error, 1)
+//	go func() { errCh <- client.StreamCompletion(req, ch) }()
+//	for event := range ch { ... }
+//	if err := <-errCh; err != nil { ... }
+func (s *Client) StreamCompletion(req *CompletionRequest, responseChannel chan<- CompletionResponse) error {
+	return s.StreamCompletionWithContext(context.Background(), req, responseChannel)
+}
+
+// StreamCompletionWithContext is like StreamCompletion but accepts a context for cancellation.
+// Cancelling ctx stops the stream and returns ctx.Err().
+func (s *Client) StreamCompletionWithContext(
+	ctx context.Context,
+	req *CompletionRequest,
+	responseChannel chan<- CompletionResponse,
+) error {
+	if responseChannel == nil {
+		return ErrNilResponseChannel
+	}
+	if req == nil {
+		return ErrNilRequest
+	}
+	defer close(responseChannel)
+	return s.streamSSE(ctx, req, responseChannel)
+}
+
 // SendSSEHTTPRequest sends a completion request to the Perplexity API using Server-Sent Events.
-// It writes each response (event) on the channel responseChannel
-// The channel will be closed when the request is done.
+// The caller must call wg.Add(1) before invoking; this function calls wg.Done() on return and
+// closes responseChannel when the request is done.
+//
+// Deprecated: Use StreamCompletion, which does not require a WaitGroup and applies backpressure
+// instead of silently dropping events when the consumer is not ready.
 func (s *Client) SendSSEHTTPRequest(wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error {
 	return s.SendSSEHTTPRequestWithContext(context.Background(), wg, req, responseChannel)
 }
 
-// SendSSEHTTPRequestWithContext sends a completion request to the Perplexity API using Server-Sent Events with the given context.
-// It writes each response (event) on the provided responseChannel.
-// The channel will be closed when the request is done.
-func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error { //nolint:gocognit,cyclop
+// SendSSEHTTPRequestWithContext is like SendSSEHTTPRequest but accepts a context for cancellation.
+//
+// Deprecated: Use StreamCompletionWithContext, which does not require a WaitGroup and applies
+// backpressure instead of silently dropping events when the consumer is not ready.
+func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.WaitGroup, req *CompletionRequest, responseChannel chan<- CompletionResponse) error {
 	if responseChannel == nil {
 		return ErrNilResponseChannel
 	}
@@ -168,10 +204,15 @@ func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.Wai
 	if req == nil {
 		return ErrNilRequest
 	}
-
 	defer close(responseChannel)
 	defer wg.Done()
+	return s.streamSSE(ctx, req, responseChannel)
+}
 
+// streamSSE performs the actual SSE round-trip, decoding events and sending them on
+// responseChannel. It does NOT close responseChannel; callers own the channel lifecycle.
+// The send is blocking (with ctx.Done() as an escape hatch), so events are never dropped.
+func (s *Client) streamSSE(ctx context.Context, req *CompletionRequest, responseChannel chan<- CompletionResponse) error { //nolint:gocognit,cyclop
 	requestBody, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %w", err)
@@ -225,38 +266,40 @@ func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.Wai
 		}
 
 		// Check if this is a data line and remove the "data: " prefix
-		if data, found := bytes.CutPrefix(line, []byte("data: ")); found { //nolint:nestif
-			data = bytes.TrimSpace(data)
+		data, found := bytes.CutPrefix(line, []byte("data: "))
+		if !found {
+			continue
+		}
+		data = bytes.TrimSpace(data)
 
-			// Check for [DONE] message
-			if bytes.Equal(data, []byte("[DONE]")) {
-				break
-			}
+		// Check for [DONE] message
+		if bytes.Equal(data, []byte("[DONE]")) {
+			break
+		}
 
-			// Try to parse the JSON data
-			var r CompletionResponse
-			if err := json.Unmarshal(data, &r); err != nil {
-				// If we have a buffer, try to append to it
-				if buffer.Len() > 0 {
-					buffer.Write(data)
-					if err := json.Unmarshal(buffer.Bytes(), &r); err != nil {
-						// If we still can't parse, continue collecting
-						continue
-					}
-					buffer.Reset()
-				} else {
-					// Start buffering incomplete JSON
-					buffer.Write(data)
+		// Try to parse the JSON data
+		var r CompletionResponse
+		if err := json.Unmarshal(data, &r); err != nil {
+			// If we have a buffer, try to append to it
+			if buffer.Len() > 0 {
+				buffer.Write(data)
+				if err := json.Unmarshal(buffer.Bytes(), &r); err != nil {
+					// If we still can't parse, continue collecting
 					continue
 				}
+				buffer.Reset()
+			} else {
+				// Start buffering incomplete JSON
+				buffer.Write(data)
+				continue
 			}
+		}
 
-			// Send the response to the channel
-			select {
-			case responseChannel <- r:
-			default:
-				// Don't block if the channel is full
-			}
+		// Blocking send: respects ctx cancellation, never drops events.
+		select {
+		case responseChannel <- r:
+		case <-ctx.Done():
+			return fmt.Errorf("stream cancelled: %w", ctx.Err())
 		}
 	}
 

--- a/perplexity_test.go
+++ b/perplexity_test.go
@@ -1,6 +1,8 @@
 package perplexity_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -254,4 +256,106 @@ func TestSendSSEHTTPRequest(t *testing.T) {
 		err := r.SendSSEHTTPRequest(&wg, req, nil)
 		assert.NotNil(t, err)
 	})
+}
+
+// newSSEStreamServer returns an httptest server that streams `count` SSE events and flushes
+// between each write. Each event contains a single-char content message, useful for asserting
+// event delivery counts without caring about payload content.
+func newSSEStreamServer(count int, pauseBetween time.Duration) *httptest.Server {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < count; i++ {
+			fmt.Fprintf(w, "data: {\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"x\"}}]}\r\n\r\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			if pauseBetween > 0 {
+				time.Sleep(pauseBetween)
+			}
+		}
+	}))
+}
+
+func TestStreamCompletion_ReceivesAllEventsBlocking(t *testing.T) {
+	const eventCount = 20
+	ts := newSSEStreamServer(eventCount, 0)
+	defer ts.Close()
+
+	r := perplexity.NewClient(apiKey)
+	r.SetHTTPClient(ts.Client())
+	r.SetEndpoint(ts.URL)
+
+	req := perplexity.NewCompletionRequest(perplexity.WithMessages([]perplexity.Message{
+		{Role: "user", Content: "test"},
+	}), perplexity.WithStream(true))
+	assert.Nil(t, req.Validate())
+
+	// Unbuffered channel + slow consumer: blocking send must not drop events.
+	ch := make(chan perplexity.CompletionResponse)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.StreamCompletion(req, ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+		time.Sleep(2 * time.Millisecond)
+	}
+	assert.Nil(t, <-errCh)
+	assert.Equal(t, eventCount, count, "every event must reach the consumer")
+}
+
+func TestStreamCompletion_ContextCancel(t *testing.T) {
+	ts := newSSEStreamServer(200, 5*time.Millisecond)
+	defer ts.Close()
+
+	r := perplexity.NewClient(apiKey)
+	r.SetHTTPClient(ts.Client())
+	r.SetEndpoint(ts.URL)
+
+	req := perplexity.NewCompletionRequest(perplexity.WithMessages([]perplexity.Message{
+		{Role: "user", Content: "test"},
+	}), perplexity.WithStream(true))
+	assert.Nil(t, req.Validate())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan perplexity.CompletionResponse)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.StreamCompletionWithContext(ctx, req, ch)
+	}()
+
+	received := 0
+	for range ch {
+		received++
+		if received == 3 {
+			cancel()
+		}
+	}
+	err := <-errCh
+	assert.NotNil(t, err)
+	assert.True(t, errors.Is(err, context.Canceled),
+		"expected context.Canceled in error chain, got %v", err)
+}
+
+func TestStreamCompletion_NilRequest(t *testing.T) {
+	r := perplexity.NewClient(apiKey)
+	ch := make(chan perplexity.CompletionResponse, 1)
+	err := r.StreamCompletion(nil, ch)
+	assert.ErrorIs(t, err, perplexity.ErrNilRequest)
+	// Caller-provided channel must not be closed on validation failure — the caller still owns it.
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok, "channel should remain open after validation error")
+	default:
+	}
+}
+
+func TestStreamCompletion_NilChannel(t *testing.T) {
+	r := perplexity.NewClient(apiKey)
+	req := perplexity.NewCompletionRequest()
+	err := r.StreamCompletion(req, nil)
+	assert.ErrorIs(t, err, perplexity.ErrNilResponseChannel)
 }


### PR DESCRIPTION
- add StreamCompletion / StreamCompletionWithContext with blocking send
  so slow consumers apply backpressure instead of dropping events
- extract shared streamSSE helper; deprecate SendSSEHTTPRequest and
  SendSSEHTTPRequestWithContext (kept for backward compatibility)
- update cmd/streaming-sse example to drop sync.WaitGroup in favor of
  an error channel
- add tests: full delivery under slow consumer, context cancellation,
  nil request, nil channel

Closes #132