### PR TITLE
chore(lint): bump golangci-lint and resolve new findings

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,9 +25,9 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: golangci/golangci-lint
-          tag: v2.10.1
+          tag: v2.11.1
           cache: enable
-          binaries-location: golangci-lint-2.10.1-linux-amd64
+          binaries-location: golangci-lint-2.11.1-linux-amd64
 
       - name: Run linter
         shell: /usr/bin/bash {0}

--- a/perplexity.go
+++ b/perplexity.go
@@ -121,7 +121,7 @@ func (s *Client) SendCompletionRequestWithContext(ctx context.Context, req *Comp
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+s.apiKey)
 	httpReq.Header.Set("Content-Type", "application/json")
-	resp, err := s.httpClient.Do(httpReq) //nolint:gosec // endpoint is a hardcoded constant or explicitly set by the caller
+	resp, err := s.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
@@ -209,6 +209,194 @@ func (s *Client) SendSSEHTTPRequestWithContext(ctx context.Context, wg *sync.Wai
 	return s.streamSSE(ctx, req, responseChannel)
 }
 
+// CreateAsyncJob creates a new async job for long-running Sonar Deep Research tasks.
+func (s *Client) CreateAsyncJob(req *AsyncJobRequest) (*AsyncJobResponse, error) {
+	return s.CreateAsyncJobWithContext(context.Background(), req)
+}
+
+// CreateAsyncJobWithContext creates a new async job with the given context.
+func (s *Client) CreateAsyncJobWithContext(ctx context.Context, req *AsyncJobRequest) (*AsyncJobResponse, error) {
+	if err := s.validateAsyncJobRequest(req); err != nil {
+		return nil, err
+	}
+
+	httpReq, err := s.prepareAsyncJobRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return s.handleAsyncJobResponse(resp)
+}
+
+// GetAsyncJob retrieves the status and result of an async job by ID.
+func (s *Client) GetAsyncJob(jobID string) (*AsyncJobResponse, error) {
+	return s.GetAsyncJobWithContext(context.Background(), jobID)
+}
+
+// GetAsyncJobWithContext retrieves the status and result of an async job by ID with the given context.
+func (s *Client) GetAsyncJobWithContext(ctx context.Context, jobID string) (*AsyncJobResponse, error) {
+	if jobID == "" {
+		return nil, ErrJobIDEmpty
+	}
+
+	url := fmt.Sprintf("%s/%s", s.asyncEndpoint, jobID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+s.apiKey)
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check return status code
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrAsyncJobNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected status code (%d) and cannot read response: %w", resp.StatusCode, err)
+		}
+		return nil, ParseErrorMessage(body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result AsyncJobResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w - body response=%s", err, string(body))
+	}
+
+	return &result, nil
+}
+
+// ListAsyncJobs retrieves a list of async jobs with optional pagination.
+func (s *Client) ListAsyncJobs(limit, offset int) (*AsyncJobListResponse, error) {
+	return s.ListAsyncJobsWithContext(context.Background(), limit, offset)
+}
+
+// ListAsyncJobsWithContext retrieves a list of async jobs with the given context and optional pagination.
+func (s *Client) ListAsyncJobsWithContext(ctx context.Context, limit, offset int) (*AsyncJobListResponse, error) {
+	if limit <= 0 {
+		limit = 20 // Default limit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	url := fmt.Sprintf("%s?limit=%d&offset=%d", s.asyncEndpoint, limit, offset)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+s.apiKey)
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check return status code
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected status code (%d) and cannot read response: %w", resp.StatusCode, err)
+		}
+		return nil, ParseErrorMessage(body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result AsyncJobListResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w - body response=%s", err, string(body))
+	}
+
+	return &result, nil
+}
+
+// SendSearchRequest sends a search request to the Perplexity Search API.
+// The Search API provides direct access to Perplexity's real-time web index
+// without the generative LLM layer, returning raw ranked search results.
+func (s *Client) SendSearchRequest(req *SearchRequest) (*SearchResponse, error) {
+	return s.SendSearchRequestWithContext(context.Background(), req)
+}
+
+// SendSearchRequestWithContext sends a search request to the Perplexity Search API with the given context.
+func (s *Client) SendSearchRequestWithContext(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
+	if req == nil {
+		return nil, ErrNilRequest
+	}
+
+	requestBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, s.searchEndpoint, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+s.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check return status code
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected status code (%d) and cannot read response: %w", resp.StatusCode, err)
+		}
+		return nil, ParseErrorMessage(body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result SearchResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %w - body response=%s", err, string(body))
+	}
+
+	return &result, nil
+}
+
 // streamSSE performs the actual SSE round-trip, decoding events and sending them on
 // responseChannel. It does NOT close responseChannel; callers own the channel lifecycle.
 // The send is blocking (with ctx.Done() as an escape hatch), so events are never dropped.
@@ -229,7 +417,7 @@ func (s *Client) streamSSE(ctx context.Context, req *CompletionRequest, response
 	httpReq.Header.Set("Cache-Control", "no-cache")
 	httpReq.Header.Set("Connection", "keep-alive")
 
-	resp, err := s.httpClient.Do(httpReq) //nolint:gosec // endpoint is a hardcoded constant or explicitly set by the caller
+	resp, err := s.httpClient.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
@@ -304,194 +492,6 @@ func (s *Client) streamSSE(ctx context.Context, req *CompletionRequest, response
 	}
 
 	return nil
-}
-
-// CreateAsyncJob creates a new async job for long-running Sonar Deep Research tasks.
-func (s *Client) CreateAsyncJob(req *AsyncJobRequest) (*AsyncJobResponse, error) {
-	return s.CreateAsyncJobWithContext(context.Background(), req)
-}
-
-// CreateAsyncJobWithContext creates a new async job with the given context.
-func (s *Client) CreateAsyncJobWithContext(ctx context.Context, req *AsyncJobRequest) (*AsyncJobResponse, error) {
-	if err := s.validateAsyncJobRequest(req); err != nil {
-		return nil, err
-	}
-
-	httpReq, err := s.prepareAsyncJobRequest(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.httpClient.Do(httpReq) //nolint:gosec // endpoint is a hardcoded constant or explicitly set by the caller
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	return s.handleAsyncJobResponse(resp)
-}
-
-// GetAsyncJob retrieves the status and result of an async job by ID.
-func (s *Client) GetAsyncJob(jobID string) (*AsyncJobResponse, error) {
-	return s.GetAsyncJobWithContext(context.Background(), jobID)
-}
-
-// GetAsyncJobWithContext retrieves the status and result of an async job by ID with the given context.
-func (s *Client) GetAsyncJobWithContext(ctx context.Context, jobID string) (*AsyncJobResponse, error) {
-	if jobID == "" {
-		return nil, ErrJobIDEmpty
-	}
-
-	url := fmt.Sprintf("%s/%s", s.asyncEndpoint, jobID)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+s.apiKey)
-
-	resp, err := s.httpClient.Do(httpReq) //nolint:gosec // endpoint is a hardcoded constant or explicitly set by the caller
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Check return status code
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrAsyncJobNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, ErrUnauthorized
-		}
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("unexpected status code (%d) and cannot read response: %w", resp.StatusCode, err)
-		}
-		return nil, ParseErrorMessage(body)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	var result AsyncJobResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response body: %w - body response=%s", err, string(body))
-	}
-
-	return &result, nil
-}
-
-// ListAsyncJobs retrieves a list of async jobs with optional pagination.
-func (s *Client) ListAsyncJobs(limit, offset int) (*AsyncJobListResponse, error) {
-	return s.ListAsyncJobsWithContext(context.Background(), limit, offset)
-}
-
-// ListAsyncJobsWithContext retrieves a list of async jobs with the given context and optional pagination.
-func (s *Client) ListAsyncJobsWithContext(ctx context.Context, limit, offset int) (*AsyncJobListResponse, error) {
-	if limit <= 0 {
-		limit = 20 // Default limit
-	}
-	if offset < 0 {
-		offset = 0
-	}
-
-	url := fmt.Sprintf("%s?limit=%d&offset=%d", s.asyncEndpoint, limit, offset)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+s.apiKey)
-
-	resp, err := s.httpClient.Do(httpReq) //nolint:gosec // endpoint is a hardcoded constant or explicitly set by the caller
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Check return status code
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, ErrUnauthorized
-		}
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("unexpected status code (%d) and cannot read response: %w", resp.StatusCode, err)
-		}
-		return nil, ParseErrorMessage(body)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	var result AsyncJobListResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response body: %w - body response=%s", err, string(body))
-	}
-
-	return &result, nil
-}
-
-// SendSearchRequest sends a search request to the Perplexity Search API.
-// The Search API provides direct access to Perplexity's real-time web index
-// without the generative LLM layer, returning raw ranked search results.
-func (s *Client) SendSearchRequest(req *SearchRequest) (*SearchResponse, error) {
-	return s.SendSearchRequestWithContext(context.Background(), req)
-}
-
-// SendSearchRequestWithContext sends a search request to the Perplexity Search API with the given context.
-func (s *Client) SendSearchRequestWithContext(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
-	if req == nil {
-		return nil, ErrNilRequest
-	}
-
-	requestBody, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request body: %w", err)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, s.searchEndpoint, bytes.NewBuffer(requestBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+s.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.httpClient.Do(httpReq) //nolint:gosec // endpoint is a hardcoded constant or explicitly set by the caller
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Check return status code
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, ErrUnauthorized
-		}
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("unexpected status code (%d) and cannot read response: %w", resp.StatusCode, err)
-		}
-		return nil, ParseErrorMessage(body)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	var result SearchResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response body: %w - body response=%s", err, string(body))
-	}
-
-	return &result, nil
 }
 
 // validateAsyncJobRequest validates the async job request.

--- a/perplexity_async_utils.go
+++ b/perplexity_async_utils.go
@@ -66,9 +66,7 @@ func (s *Client) WaitForAsyncJobWithContext(ctx context.Context, jobID string, o
 	}
 
 	ctx, cancel := s.setupTimeoutContext(ctx, opts)
-	if cancel != nil {
-		defer cancel()
-	}
+	defer cancel()
 
 	return s.pollJobUntilCompletion(ctx, jobID, opts)
 }
@@ -104,9 +102,7 @@ func (s *Client) WaitForAsyncJobWithProgress(ctx context.Context, jobID string, 
 	}
 
 	ctx, cancel := s.setupTimeoutContext(ctx, opts)
-	if cancel != nil {
-		defer cancel()
-	}
+	defer cancel()
 	interval := opts.InitialInterval
 
 	for {
@@ -144,11 +140,12 @@ func (s *Client) validateJobIDAndOptions(jobID string, opts **AsyncPollingOption
 }
 
 // setupTimeoutContext creates a timeout context if MaxWaitTime is set.
+// The returned cancel function is always non-nil; the caller is responsible for calling it.
 func (s *Client) setupTimeoutContext(ctx context.Context, opts *AsyncPollingOptions) (context.Context, context.CancelFunc) {
 	if opts.MaxWaitTime > 0 {
-		return context.WithTimeout(ctx, opts.MaxWaitTime)
+		return context.WithTimeout(ctx, opts.MaxWaitTime) //nolint:gosec // caller defers cancel()
 	}
-	return ctx, nil
+	return context.WithCancel(ctx) //nolint:gosec // caller defers cancel()
 }
 
 // checkContextDone checks if the context is done and returns appropriate error.

--- a/perplexity_file.go
+++ b/perplexity_file.go
@@ -165,7 +165,7 @@ func (p *FileProcessor) CheckFileURLAccessibility(ctx context.Context, fileURL s
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is validated as HTTPS before this call
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("file URL not accessible: %w", err)
 	}

--- a/perplexity_image.go
+++ b/perplexity_image.go
@@ -166,7 +166,7 @@ func (p *ImageProcessor) CheckImageURLAccessibility(ctx context.Context, imageUR
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is validated as HTTPS before this call
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("image URL not accessible: %w", err)
 	}


### PR DESCRIPTION
- Bump golangci-lint 2.10.1 → 2.11.1 in CI workflow
- Remove unused //nolint:gosec directives flagged by nolintlint
- Move streamSSE below exported methods to satisfy funcorder
- Always return non-nil cancel from setupTimeoutContext to silence gosec G118